### PR TITLE
Bugfix/61325-área-lojistas-remover-validação-no-campo-nome-completo

### DIFF
--- a/src/screens/AreaLogada/DadosEmpresaLogado/Cadastro/components/DadosEmpresa/index.jsx
+++ b/src/screens/AreaLogada/DadosEmpresaLogado/Cadastro/components/DadosEmpresa/index.jsx
@@ -11,7 +11,6 @@ import {
   validaTelefoneOuCelular,
   validaEmail,
   somenteAlfanumericos,
-  somenteCaracteresEEspacos,
   validaCNPJ,
 } from "helpers/fieldValidators";
 import { toastError } from "components/Toast/dialogs";
@@ -146,7 +145,7 @@ export const DadosEmpresa = ({ empresa, form, values }) => {
             type="text"
             placeholder="Nome completo"
             required
-            validate={composeValidators(required, somenteCaracteresEEspacos)}
+            validate={required}
             disabled={empresa}
           />
         </div>

--- a/src/screens/AreaLogada/DadosEmpresaLogado/Cadastro/components/DadosEmpresa/index.jsx
+++ b/src/screens/AreaLogada/DadosEmpresaLogado/Cadastro/components/DadosEmpresa/index.jsx
@@ -8,9 +8,7 @@ import {
   composeValidators,
   required,
   validaCEP,
-  validaTelefoneOuCelular,
   validaEmail,
-  somenteAlfanumericos,
   validaCNPJ,
 } from "helpers/fieldValidators";
 import { toastError } from "components/Toast/dialogs";


### PR DESCRIPTION
# Proposta

Este PR visa remover validação de acento, cedilha e espaços no campo Nome completo da área de lojistas

# Referência do Azure

- 61325

# Tarefas para concluir

- [x] remover validação de acento, cedilha e espaços no campo Nome completo
- [x] remover funções não utilizadas