### PR TITLE
Feature(148709): Parametrização de Tipos Documentos e Upload Documentos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,4 +117,7 @@ fabric.properties
 .idea/**/markdown-navigator.xml
 .idea/**/markdown-navigator/
 
+#github
+.github/
+
 # End of https://www.gitignore.io/api/webstorm

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,20 @@
+services:
+  frontend:
+    image: node:10.15.3
+    working_dir: /app
+    init: true
+    ports:
+      - "3000:3000"
+    environment:
+      HOST: 0.0.0.0
+      BROWSER: none
+      CHOKIDAR_USEPOLLING: "true"
+    env_file:
+      - .env
+    volumes:
+      - .:/app
+      - portal_uniforme_frontend_node_modules:/app/node_modules
+    command: sh -c "npm install && npm start"
+
+volumes:
+  portal_uniforme_frontend_node_modules:

--- a/src/components/Input/FileUpload.jsx
+++ b/src/components/Input/FileUpload.jsx
@@ -3,6 +3,7 @@ import { FileUpload as FileUploadPR } from "primereact/fileupload";
 
 import { InputErroMensagem } from "./InputErroMensagem";
 import { HelpText } from "components/HelpText";
+import { isAcceptedFile } from "helpers/fileUpload";
 import { asyncForEach, readerFile } from "helpers/utils";
 import { toastError } from "components/Toast/dialogs";
 
@@ -10,10 +11,13 @@ class CustomFileUploadPR extends FileUploadPR {
   async upload() {
     const { onUploadChange } = this.props;
     const { files } = this.state;
-    if (
+    const hasInvalidFile =
       this.props.acceptCustom &&
-      files[0] &&
-      !this.props.acceptCustom.includes(files[0].type)
+      files.some(file => !isAcceptedFile(file, this.props.acceptCustom));
+
+    if (
+      files.length > 0 &&
+      hasInvalidFile
     ) {
       toastError("Formato de arquivo inválido");
       this.setState({ files: [] });

--- a/src/components/Input/FileUpload.test.js
+++ b/src/components/Input/FileUpload.test.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { mount } from "enzyme";
 
-import { required } from "helpers/fieldValidators";
 import { FileUpload } from "./FileUpload";
 
 describe("test <FileUpload>", () => {
@@ -29,7 +28,6 @@ describe("test <FileUpload>", () => {
         label="mylabel"
         required
         value=""
-        validate={required}
         {...props}
       />
     );

--- a/src/components/Input/__snapshots__/FileUpload.test.js.snap
+++ b/src/components/Input/__snapshots__/FileUpload.test.js.snap
@@ -18,39 +18,46 @@ exports[`test <FileUpload> renders component 1`] = `
   }
   name="myCombo"
   required={true}
-  validate={[Function]}
   value=""
 >
   <div
     className="input"
   >
-    <span
-      className="required-asterisk"
-      key="1"
+    <div
+      style={
+        Object {
+          "display": "flex",
+        }
+      }
     >
-      *
-    </span>
-    <label
-      className="col-form-label undefined"
-      htmlFor="myCombo"
-      key="2"
-    >
-      mylabel
-    </label>
+      <span
+        className="required-asterisk"
+        key="1"
+      >
+        *
+      </span>
+      <label
+        className="col-form-label undefined"
+        htmlFor="myCombo"
+        key="2"
+      >
+        mylabel
+      </label>
+    </div>
     <CustomFileUploadPR
       accept={null}
       auto={true}
       cancelLabel="Cancelar"
-      chooseLabel="Selecione os arquivos"
+      chooseLabel="Selecione o arquivo"
       className="teste 
              invalid-field"
       disabled={false}
       id={null}
-      invalidFileSizeMessageDetail="maximum upload size is {0}."
-      invalidFileSizeMessageSummary="{0}: Invalid file size, "
-      maxFileSize={2097152}
+      invalidFileSizeMessageDetail="O tamanho máximo de um arquivo é 5MB"
+      invalidFileSizeMessageSummary="Erro ao dar upload:"
+      maxFileSize={5242880}
       mode="advanced"
-      multiple={true}
+      multiple={false}
       name="myCombo"
       onBeforeSend={null}
       onBeforeUpload={null}
@@ -85,7 +92,7 @@ exports[`test <FileUpload> renders component 1`] = `
             <input
               accept={null}
               disabled={false}
-              multiple={true}
+              multiple={false}
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
@@ -97,7 +104,7 @@ exports[`test <FileUpload> renders component 1`] = `
             <span
               className="p-button-text p-clickable"
             >
-              Selecione os arquivos
+              Selecione o arquivo
             </span>
           </span>
         </div>
@@ -133,7 +140,7 @@ exports[`test <FileUpload> renders component 1`] = `
     </CustomFileUploadPR>
     <HelpText>
       <div
-        className="help-text"
+        className="help-text undefined"
       />
     </HelpText>
     <InputErroMensagem

--- a/src/helpers/fileUpload.js
+++ b/src/helpers/fileUpload.js
@@ -1,0 +1,55 @@
+export const FACHADA_ACCEPT = ".png,.jpg,.jpeg";
+export const FACHADA_ACCEPT_CUSTOM = [
+  "image/png",
+  "image/jpg",
+  "image/jpeg",
+  ".png",
+  ".jpg",
+  ".jpeg",
+];
+
+export const DOCUMENTO_ACCEPT = ".pdf";
+export const DOCUMENTO_ACCEPT_CUSTOM = ["application/pdf", ".pdf"];
+
+export const FACHADA_HELPER_TEXT = "Formatos permitidos: .png, .jpg, .jpeg";
+export const DOCUMENTO_HELPER_TEXT = "Formato permitido: .pdf";
+export const TAMANHO_MAXIMO_UPLOAD = "Tamanho máximo: 5 MB";
+
+const normalizeAcceptedFileTypes = (acceptedFileTypes = []) => {
+  if (Array.isArray(acceptedFileTypes)) {
+    return acceptedFileTypes.map((fileType) => fileType.toLowerCase());
+  }
+
+  return acceptedFileTypes
+    .split(",")
+    .map((fileType) => fileType.trim().toLowerCase())
+    .filter(Boolean);
+};
+
+const getFileExtension = (fileName = "") => {
+  const lastDotIndex = fileName.lastIndexOf(".");
+
+  if (lastDotIndex < 0) {
+    return "";
+  }
+
+  return fileName.slice(lastDotIndex).toLowerCase();
+};
+
+export const isAcceptedFile = (file, acceptedFileTypes = []) => {
+  const normalizedAcceptedFileTypes = normalizeAcceptedFileTypes(
+    acceptedFileTypes
+  );
+
+  if (!file || normalizedAcceptedFileTypes.length === 0) {
+    return true;
+  }
+
+  const mimeType = (file.type || "").toLowerCase();
+  const fileExtension = getFileExtension(file.name);
+
+  return normalizedAcceptedFileTypes.some(
+    (acceptedFileType) =>
+      acceptedFileType === mimeType || acceptedFileType === fileExtension
+  );
+};

--- a/src/helpers/fileUpload.test.js
+++ b/src/helpers/fileUpload.test.js
@@ -1,0 +1,31 @@
+import {
+  DOCUMENTO_ACCEPT_CUSTOM,
+  FACHADA_ACCEPT_CUSTOM,
+  isAcceptedFile,
+} from "./fileUpload";
+
+describe("helpers/fileUpload", () => {
+  it("aceita pdf para anexos gerais", () => {
+    const file = new File(["dummy content"], "documento.pdf", {
+      type: "application/pdf",
+    });
+
+    expect(isAcceptedFile(file, DOCUMENTO_ACCEPT_CUSTOM)).toBe(true);
+  });
+
+  it("rejeita imagem para anexos gerais", () => {
+    const file = new File(["dummy content"], "documento.png", {
+      type: "image/png",
+    });
+
+    expect(isAcceptedFile(file, DOCUMENTO_ACCEPT_CUSTOM)).toBe(false);
+  });
+
+  it("aceita jpg para fachada", () => {
+    const file = new File(["dummy content"], "fachada.jpg", {
+      type: "image/jpeg",
+    });
+
+    expect(isAcceptedFile(file, FACHADA_ACCEPT_CUSTOM)).toBe(true);
+  });
+});

--- a/src/screens/AreaLogada/AnexosLogado/Arquivos/index.jsx
+++ b/src/screens/AreaLogada/AnexosLogado/Arquivos/index.jsx
@@ -18,6 +18,15 @@ import "primereact/resources/themes/nova-light/theme.css";
 import "./style.scss";
 import { formataEmpresa } from "screens/AreaLogada/DadosEmpresaLogado/helpers";
 import {
+  DOCUMENTO_ACCEPT,
+  DOCUMENTO_ACCEPT_CUSTOM,
+  DOCUMENTO_HELPER_TEXT,
+  FACHADA_ACCEPT,
+  FACHADA_ACCEPT_CUSTOM,
+  FACHADA_HELPER_TEXT,
+  TAMANHO_MAXIMO_UPLOAD,
+} from "helpers/fileUpload";
+import {
   deleteAnexo,
   getTiposDocumentos,
   setAnexo,
@@ -60,36 +69,32 @@ export const Arquivos = ({ empresa, setEmpresa, values, logado }) => {
   };
 
   const uploadFachadaLoja = async (e, uuidLoja, key) => {
-    if (!e[0].arquivo.includes("image/")) {
-      toastError("Formato de arquivo inválido");
-    } else {
-      const arquivoAnexo = {
-        foto_fachada: e[0].arquivo,
-      };
-      let empresa_ = empresa;
-      empresa_.lojas[key].uploadEmAndamento = true;
-      setEmpresa(empresa_);
-      setAlgumUploadEmAndamento(true);
-      forceUpdate();
-      setFachadaLoja(arquivoAnexo, uuidLoja).then((response) => {
-        if (response.status === HTTP_STATUS.OK) {
-          toastSuccess("Arquivo salvo com sucesso!");
-          let empresa_ = empresa;
-          empresa_.lojas[key].uploadEmAndamento = false;
-          setEmpresa(empresa_);
-          setAlgumUploadEmAndamento(false);
-          getProponente(empresa.uuid).then((empresa) => {
-            setEmpresaEFaltaArquivos(empresa.data);
-          });
-        } else {
-          toastError("Erro ao dar upload no arquivo");
-          let empresa_ = empresa;
-          empresa_.lojas[key].uploadEmAndamento = false;
-          setEmpresa(formataEmpresa(empresa_));
-          setAlgumUploadEmAndamento(false);
-        }
-      });
-    }
+    const arquivoAnexo = {
+      foto_fachada: e[0].arquivo,
+    };
+    let empresa_ = empresa;
+    empresa_.lojas[key].uploadEmAndamento = true;
+    setEmpresa(empresa_);
+    setAlgumUploadEmAndamento(true);
+    forceUpdate();
+    setFachadaLoja(arquivoAnexo, uuidLoja).then((response) => {
+      if (response.status === HTTP_STATUS.OK) {
+        toastSuccess("Arquivo salvo com sucesso!");
+        let empresa_ = empresa;
+        empresa_.lojas[key].uploadEmAndamento = false;
+        setEmpresa(empresa_);
+        setAlgumUploadEmAndamento(false);
+        getProponente(empresa.uuid).then((empresa) => {
+          setEmpresaEFaltaArquivos(empresa.data);
+        });
+      } else {
+        toastError("Erro ao dar upload no arquivo");
+        let empresa_ = empresa;
+        empresa_.lojas[key].uploadEmAndamento = false;
+        setEmpresa(formataEmpresa(empresa_));
+        setAlgumUploadEmAndamento(false);
+      }
+    });
   };
 
   const deleteFachadaLoja = async (uuidLoja) => {
@@ -127,7 +132,7 @@ export const Arquivos = ({ empresa, setEmpresa, values, logado }) => {
 
   const uploadAnexo = async (e, tipo, key, values) => {
     const arquivoAnexo = {
-      ...e[0],
+      arquivo: e[0].arquivo,
       tipo_documento: tipo.id,
       proponente: empresa.uuid,
       data_validade: values[`data_validade_${key}`],
@@ -196,8 +201,8 @@ export const Arquivos = ({ empresa, setEmpresa, values, logado }) => {
                     disabled={algumUploadEmAndamento}
                     id={`${key}`}
                     key={key}
-                    accept="image/*"
-                    acceptCustom="image/png, image/jpg, image/jpeg"
+                    accept={FACHADA_ACCEPT}
+                    acceptCustom={FACHADA_ACCEPT_CUSTOM}
                     className="form-control-file"
                     label={`${loja.nome_fantasia} - ${loja.endereco}`}
                     required
@@ -205,9 +210,9 @@ export const Arquivos = ({ empresa, setEmpresa, values, logado }) => {
                     multiple={false}
                   />
                   <div className="campos-permitidos">
-                    Formatos permitidos: .png, .jpg, .jpeg
+                    {FACHADA_HELPER_TEXT}
                     <br />
-                    Tamanho máximo: 5 MB
+                    {TAMANHO_MAXIMO_UPLOAD}
                   </div>
                   <OnChange name={`loja_${key}`}>
                     {async (value, previous) => {
@@ -282,8 +287,8 @@ export const Arquivos = ({ empresa, setEmpresa, values, logado }) => {
                     name={`arqs_${key}`}
                     id={`${key}`}
                     key={key}
-                    accept=".pdf, .png, .jpg, .jpeg, .zip"
-                    acceptCustom="image/png, image/jpg, image/jpeg, application/zip, application/pdf"
+                    accept={DOCUMENTO_ACCEPT}
+                    acceptCustom={DOCUMENTO_ACCEPT_CUSTOM}
                     className="form-control-file"
                     label={htmlTextToDiv(tipo)}
                     resetarFile={tipo.resetarFile}
@@ -312,9 +317,9 @@ export const Arquivos = ({ empresa, setEmpresa, values, logado }) => {
                             </strong>
                           </div>
                         )}
-                        Formatos permitidos: .png, .jpg, .jpeg, .zip, .pdf
+                        {DOCUMENTO_HELPER_TEXT}
                         <br />
-                        Tamanho máximo: 5 MB
+                        {TAMANHO_MAXIMO_UPLOAD}
                       </div>
                       {tipo.tem_data_validade && (
                         <div className="data-validade">

--- a/src/screens/AreaLogada/DadosEmpresaLogado/Cadastro/components/DadosLoja/index.jsx
+++ b/src/screens/AreaLogada/DadosEmpresaLogado/Cadastro/components/DadosLoja/index.jsx
@@ -16,7 +16,6 @@ import {
   validaTelefoneOuCelular,
   validaTelefoneOuCelularLength
 } from "helpers/fieldValidators";
-import { FileUpload } from "components/Input/FileUpload";
 import formatStringByPattern from "format-string-by-pattern";
 import { OnChange } from "react-final-form-listeners";
 import { toastError } from "components/Toast/dialogs";
@@ -26,7 +25,6 @@ import "./style.scss"
 
 export const Loja = ({ loja, fields, index, empresa, logado }) => {
   const [apiCEPfora, setApiCEPfora] = useState(false);
-  const [comprovanteUpado, setComprovanteUpado] = useState(false);
 
   return (
     <div key={loja}>
@@ -172,33 +170,6 @@ export const Loja = ({ loja, fields, index, empresa, logado }) => {
           />
         </div>
       </div>
-
-      {empresa.lojas[index] &&
-        <div class="link-comprovante">
-          <label class="form-label">Comprovante de endereço do ponto de venda</label>     
-          <div>
-            <a class="btn btn-comprovante btn-primary" target="blank" href={`${empresa.lojas[index].comprovante_endereco}`}> Visualizar comprovante</a>
-          </div>
-        </div>
-      }
-      <Field
-        component={FileUpload}
-        name={`${loja}.comprovante_endereco`}
-        disabled={comprovanteUpado}
-        accept="image/*, .pdf"
-        acceptCustom="application/pdf, image/png, image/jpg, image/jpeg"
-        className="form-control-file"
-        label={empresa.lojas[index] ? `Substituir o Comprovante de endereço do ponto de venda:` : `Comprovante de endereço do ponto de venda:` }
-        required={!empresa.lojas[index]}
-        multiple={true}
-      />
-      <OnChange name={`${loja}.comprovante_endereco`}>
-        {(value) => {
-          if(Array.isArray(value)){
-            setComprovanteUpado(value.length > 0);
-          } 
-        }}
-      </OnChange>
       <Field
         component={InputText}
         placeholder={"Site"}

--- a/src/screens/AreaLogada/DadosEmpresaLogado/Cadastro/components/DadosLoja/index.test.jsx
+++ b/src/screens/AreaLogada/DadosEmpresaLogado/Cadastro/components/DadosLoja/index.test.jsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { mount } from "enzyme";
+import { Form } from "react-final-form";
+
+import { Loja } from "./index";
+
+jest.mock("helpers/fieldValidators", () => ({
+  composeValidators: jest.fn(() => undefined),
+  required: jest.fn(() => undefined),
+  validaCEP: jest.fn(() => undefined),
+  validaRangeCEP: jest.fn(() => undefined),
+  validaTelefoneOuCelular: jest.fn(() => undefined),
+  validaTelefoneOuCelularLength: jest.fn(() => undefined),
+}));
+
+describe("DadosEmpresaLogado/Cadastro/components/DadosLoja", () => {
+  it("nao renderiza o campo de comprovante de endereco", () => {
+    const fields = {
+      length: 1,
+      remove: jest.fn(),
+      update: jest.fn(),
+      value: [
+        {
+          bairro: "Centro",
+          cep: "01000-000",
+          cidade: "São Paulo",
+          complemento: "",
+          endereco: "Rua A",
+          nome_fantasia: "Loja Teste",
+          numero: "10",
+          site: "",
+          telefone: "11999999999",
+          uf: "SP",
+        },
+      ],
+    };
+
+    const wrapper = mount(
+      <Form
+        initialValues={{ lojas: fields.value }}
+        onSubmit={jest.fn()}
+        render={() => (
+          <Loja
+            empresa={{}}
+            fields={fields}
+            index={0}
+            loja="lojas[0]"
+            logado={true}
+          />
+        )}
+      />
+    );
+
+    expect(wrapper.text()).not.toContain(
+      "Comprovante de endereço do ponto de venda"
+    );
+  });
+});

--- a/src/screens/AreaLogada/DadosEmpresaLogado/helpers.js
+++ b/src/screens/AreaLogada/DadosEmpresaLogado/helpers.js
@@ -48,7 +48,7 @@ export const formataPayloadLojasPrecos = (values, tiposDeUniforme) => {
   // Formata comprovante de endereços de cada loja
   values.lojas.forEach(loja =>{
 
-    if(loja.comprovante_endereco && loja.comprovante_endereco[0])
+    if(Array.isArray(loja.comprovante_endereco) && loja.comprovante_endereco[0])
       loja.comprovante_endereco = loja.comprovante_endereco[0].arquivo
     else
       delete loja.comprovante_endereco

--- a/src/screens/CadastroEmpresa/LojaFisica.jsx
+++ b/src/screens/CadastroEmpresa/LojaFisica.jsx
@@ -1,8 +1,5 @@
 import axios from "axios";
 import React, { Fragment, useState, useEffect } from "react";
-import { Field } from "redux-form";
-import { requiredImagem } from "helpers/fieldValidators";
-import { FileUpload } from "components/Input/FileUpload";
 import { Row, Col } from "react-bootstrap";
 import {
   InputLabelRequired,
@@ -21,8 +18,6 @@ const LojaFisica = (props) => {
   const [cidade, setCidade] = useState("");
   const [uf, setUf] = useState("");
   const [site, setSite] = useState("");
-  const [comprovanteEndereco, setComprovanteEndereco] = useState(null);
-  const [comprovanteUpado, setComprovanteUpado] = useState(false);
   const [payload, setPayload] = useState({});
   const [erro, setErro] = useState(false);
   const [nome_fantasia, setNomeFantasia] = useState("");
@@ -38,7 +33,6 @@ const LojaFisica = (props) => {
     setComplemento(props.complemento);
     setNomeFantasia(props.nome_fantasia);
     setSite(props.site);
-    setComprovanteEndereco(props.comprovante_endereco)
   }, [props]);
 
   const buscaCep = async (value) => {
@@ -89,7 +83,6 @@ const LojaFisica = (props) => {
       bairro: data.bairro,
       cep: data.cep,
       nome_fantasia: nome_fantasia,
-      comprovante_endereco: data.comprovanteEndereco
     };
   };
 
@@ -262,29 +255,6 @@ const LojaFisica = (props) => {
           />
         </div>
       </div>
-      <Field
-        component={FileUpload}
-        name={`comprovante_endereco_${props.chave}`}
-        disabled={comprovanteUpado}
-        id={`comprovante_endereco_${props.chave}`}
-        key={props.chave}
-        value={comprovanteEndereco}
-        accept="image/*, .pdf"
-        acceptCustom="application/pdf, image/png, image/jpg, image/jpeg"
-        className="form-control-file"
-        label={`Comprovante de endereço do ponto de venda`}
-        required
-        validate={requiredImagem}
-        multiple={true}
-        onChange={(e) => {
-          const valor = e.length > 0 ? e[0].arquivo : null;
-          setComprovanteEndereco(e);
-          setComprovanteUpado(Array.isArray(e) && e.length > 0);
-          setPayload({ ...payload, comprovante_endereco: valor });
-          props.onUpdate({ ...payload, comprovante_endereco: valor }, props.chave);
-        }}
-      />
-
       <InputLabel
         label="Site"
         value={site}

--- a/src/screens/CadastroEmpresa/LojaFisica.test.js
+++ b/src/screens/CadastroEmpresa/LojaFisica.test.js
@@ -1,0 +1,29 @@
+import React from "react";
+import { mount } from "enzyme";
+
+import LojaFisica from "./LojaFisica";
+
+describe("CadastroEmpresa/LojaFisica", () => {
+  it("nao renderiza o campo de comprovante de endereco", () => {
+    const wrapper = mount(
+      <LojaFisica
+        bairro="Centro"
+        cep="01000-000"
+        chave={0}
+        cidade="São Paulo"
+        complemento=""
+        endereco="Rua A"
+        nome_fantasia="Loja Teste"
+        numero="10"
+        onUpdate={jest.fn()}
+        site=""
+        telefone="11999999999"
+        uf="SP"
+      />
+    );
+
+    expect(wrapper.text()).not.toContain(
+      "Comprovante de endereço do ponto de venda"
+    );
+  });
+});

--- a/src/screens/CadastroEmpresa/index.jsx
+++ b/src/screens/CadastroEmpresa/index.jsx
@@ -33,6 +33,15 @@ import {
 import { FileUpload } from "components/Input/FileUpload";
 import ArquivoExistente from "./ArquivoExistente";
 import { PaginaComCabecalhoRodape } from "components/PaginaComCabecalhoRodape";
+import {
+  DOCUMENTO_ACCEPT,
+  DOCUMENTO_ACCEPT_CUSTOM,
+  DOCUMENTO_HELPER_TEXT,
+  FACHADA_ACCEPT,
+  FACHADA_ACCEPT_CUSTOM,
+  FACHADA_HELPER_TEXT,
+  TAMANHO_MAXIMO_UPLOAD,
+} from "helpers/fileUpload";
 export let CadastroEmpresa = (props) => {
   const initialValue = {
     nome_fantasia: undefined,
@@ -266,7 +275,13 @@ export let CadastroEmpresa = (props) => {
     const novoFornecimento = filtrarFornecimento(fornecimento);
 
     if (validaUniformes(novoFornecimento)) {
-      payload["lojas"] = loja;
+      payload["lojas"] = loja.map((lojaPayload) => {
+        const lojaSemComprovante = { ...lojaPayload };
+
+        delete lojaSemComprovante.comprovante_endereco;
+
+        return lojaSemComprovante;
+      });
       payload["meios_de_recebimento"] = bandeiras;
       payload["ofertas_de_uniformes"] = novoFornecimento;
       payload["arquivos_anexos"] = arquivosAnexos;
@@ -333,7 +348,7 @@ export let CadastroEmpresa = (props) => {
 
   const uploadAnexo = async (e, tipo, key) => {
     const arquivoAnexo = {
-      ...e[0],
+      arquivo: e[0].arquivo,
       tipo_documento: tipo.id,
       proponente: uuid,
       data_validade: datasValidades[key],
@@ -364,36 +379,32 @@ export let CadastroEmpresa = (props) => {
   };
 
   const uploadFachadaLoja = async (e, uuidLoja, key) => {
-    if (!e[0].arquivo.includes("image/")) {
-      toastError("Formato de arquivo inválido");
-    } else {
-      const arquivoAnexo = {
-        foto_fachada: e[0].arquivo,
-      };
-      let empresa_ = empresa;
-      empresa_.lojas[key].uploadEmAndamento = true;
-      setEmpresa(empresa_);
-      setAlgumUploadEmAndamento(true);
-      forceUpdate();
-      setFachadaLoja(arquivoAnexo, uuidLoja).then((response) => {
-        if (response.status === HTTP_STATUS.OK) {
-          toastSuccess("Arquivo salvo com sucesso!");
-          let empresa_ = empresa;
-          empresa_.lojas[key].uploadEmAndamento = false;
-          setEmpresa(empresa_);
-          setAlgumUploadEmAndamento(false);
-          getEmpresa(uuid).then((empresa) => {
-            setEmpresaEFaltaArquivos(empresa.data);
-          });
-        } else {
-          toastError("Erro ao dar upload no arquivo");
-          let empresa_ = empresa;
-          empresa_.lojas[key].uploadEmAndamento = false;
-          setEmpresa(empresa_);
-          setAlgumUploadEmAndamento(false);
-        }
-      });
-    }
+    const arquivoAnexo = {
+      foto_fachada: e[0].arquivo,
+    };
+    let empresa_ = empresa;
+    empresa_.lojas[key].uploadEmAndamento = true;
+    setEmpresa(empresa_);
+    setAlgumUploadEmAndamento(true);
+    forceUpdate();
+    setFachadaLoja(arquivoAnexo, uuidLoja).then((response) => {
+      if (response.status === HTTP_STATUS.OK) {
+        toastSuccess("Arquivo salvo com sucesso!");
+        let empresa_ = empresa;
+        empresa_.lojas[key].uploadEmAndamento = false;
+        setEmpresa(empresa_);
+        setAlgumUploadEmAndamento(false);
+        getEmpresa(uuid).then((empresa) => {
+          setEmpresaEFaltaArquivos(empresa.data);
+        });
+      } else {
+        toastError("Erro ao dar upload no arquivo");
+        let empresa_ = empresa;
+        empresa_.lojas[key].uploadEmAndamento = false;
+        setEmpresa(empresa_);
+        setAlgumUploadEmAndamento(false);
+      }
+    });
   };
 
   const deleteFachadaLoja = async (uuidLoja) => {
@@ -677,8 +688,8 @@ export let CadastroEmpresa = (props) => {
                                 disabled={algumUploadEmAndamento}
                                 id={`${key}`}
                                 key={key}
-                                accept="image/*"
-                                acceptCustom="image/png, image/jpg, image/jpeg"
+                                accept={FACHADA_ACCEPT}
+                                acceptCustom={FACHADA_ACCEPT_CUSTOM}
                                 className="form-control-file"
                                 label={`${loja.nome_fantasia} - ${loja.endereco}`}
                                 required
@@ -690,6 +701,11 @@ export let CadastroEmpresa = (props) => {
                                   }
                                 }}
                               />
+                              <div className="campos-permitidos">
+                                {FACHADA_HELPER_TEXT}
+                                <br />
+                                {TAMANHO_MAXIMO_UPLOAD}
+                              </div>
                               {loja.uploadEmAndamento && (
                                 <span className="font-weight-bold">
                                   {`Upload de documento em andamento. `}
@@ -763,8 +779,8 @@ export let CadastroEmpresa = (props) => {
                                 }
                                 id={`${key}`}
                                 key={key}
-                                accept=".pdf, .png, .jpg, .jpeg, .zip"
-                                acceptCustom="image/png, image/jpg, image/jpeg, application/zip, application/pdf"
+                                accept={DOCUMENTO_ACCEPT}
+                                acceptCustom={DOCUMENTO_ACCEPT_CUSTOM}
                                 className="form-control-file"
                                 label={labelTemplate(tipo)}
                                 resetarFile={tipo.resetarFile}
@@ -790,10 +806,9 @@ export let CadastroEmpresa = (props) => {
                                         </strong>
                                       </div>
                                     )}
-                                    Formatos permitidos: .png, .jpg, .jpeg,
-                                    .zip, .pdf
+                                    {DOCUMENTO_HELPER_TEXT}
                                     <br />
-                                    Tamanho máximo: 5 MB
+                                    {TAMANHO_MAXIMO_UPLOAD}
                                   </div>
                                   {tipo.tem_data_validade && (
                                     <div className="data-validade">


### PR DESCRIPTION
## 🎯 Objetivo

Esta PR consolida backend e frontend para adequar o fluxo de proponentes às novas regras de documentos do edital.

O foco da entrega foi:

- parametrizar tipos de documento com identificador técnico no backend;
- endurecer as regras de upload para anexos e fachada;
- remover o comprovante de endereço do ponto de venda das interfaces e do Admin;
- alinhar mensagens, labels e help texts com as regras atuais;
- manter frontend e backend consistentes nos fluxos público e autenticado.

## 🔎 Contexto

- O backend passou a expor `identificador` em `tipos-documento`, com suporte a busca e ordenação.
- O frontend foi mantido compatível com esse retorno, mas continua renderizando os tipos de documento pelo campo `nome`, já que não há uso funcional ou visual para `identificador` nas telas atuais.
- A mudança concentrou-se em comportamento, validação de arquivos e coerência entre Admin, API e interface.

## ✅ O que foi entregue

### Backend

- `TipoDocumento` passou a ter o campo `identificador`, com unicidade e validação para letras, números, hífen e underscore.
- Foi criada a migration `0032_tipodocumento_identificador`.
- O Django Admin de `TipoDocumento` passou a exigir `identificador`, inclusive em edição de registros legados sem preenchimento, e a bloquear duplicidade.
- O backend passou a centralizar validações de extensão em `sme_uniforme_apps/proponentes/upload_validation.py`.
- Uploads de anexos do proponente passaram a aceitar apenas PDF no Admin e na API.
- Uploads de `foto_fachada` passaram a aceitar apenas JPG, JPEG e PNG no Admin e na API.
- `comprovante_endereco` deixou de aparecer no Admin de loja e permaneceu opcional na API, com validação de PDF quando enviado.
- O endpoint `PATCH /proponentes/{uuid}/atualiza-lojas/` passou a validar `comprovante_endereco` antes de salvar o arquivo.
- Labels, help texts e mensagens de erro foram atualizados para refletir as regras vigentes.

### Frontend

- O campo `Comprovante de endereço do ponto de venda` foi removido do cadastro público e da edição logada de lojas.
- `comprovante_endereco` deixou de ser enviado no payload do cadastro público.
- O helper da área logada passou a tratar `comprovante_endereco` de forma defensiva apenas quando ainda vier como array, preservando compatibilidade com dados legados.
- As regras de upload foram centralizadas em um helper compartilhado.
- A fachada passou a aceitar somente `.png`, `.jpg` e `.jpeg`.
- Os demais anexos passaram a aceitar somente `.pdf`.
- Os textos auxiliares dos campos de upload foram atualizados para refletir formatos permitidos e limite de 5 MB.
- O payload de upload foi padronizado para envio do campo `arquivo` com `e[0].arquivo`.
- As telas pública e autenticada passaram a reutilizar a mesma regra de validação, reduzindo divergência entre fluxos.

## 📡 Impacto funcional

- Tipos de documento agora possuem identificador técnico padronizado e pesquisável no backend.
- Registros legados sem identificador continuam existindo, mas não podem mais ser salvos pelo Admin sem correção.
- O comprovante de endereço do ponto de venda deixa de aparecer nas interfaces do frontend e no Admin.
- O comprovante de endereço continua opcional na API de lojas, mas, quando enviado, deve ser PDF.
- Documentos anexos passam a rejeitar qualquer arquivo diferente de PDF.
- A foto da fachada passa a rejeitar PDF e qualquer formato fora de JPG, JPEG e PNG.
- Backend e frontend passam a comunicar as mesmas regras por meio de validação e textos de apoio consistentes.

## 🖥️ Fluxos impactados

- Admin de `TipoDocumento`
- Admin e inline de `Loja`
- API de `tipos-documento`
- `PATCH /lojas/{uuid}/`
- `PATCH /proponentes/{uuid}/atualiza-lojas/`
- `/cadastro`
- Aba `Anexos` do cadastro público
- `/adm-fornecedor/dados-empresa`
- `/adm-fornecedor/anexos`

## 🧪 Testes automatizados

### Backend nos testes

Cobertura adicionada e ajustada para validar:

- exposição, busca, ordenação, obrigatoriedade e unicidade de `identificador` em `TipoDocumento`;
- labels, help texts e regras de aceite de anexos do proponente;
- remoção de `comprovante_endereco` do Admin de loja;
- configuração e validação de uploads de `foto_fachada` e `comprovante_endereco` em forms, serializers e endpoints;
- sucesso e rejeição no endpoint de atualização de lojas do proponente conforme o tipo de arquivo enviado.

Arquivos de teste impactados:

- `sme_uniforme_apps/proponentes/tests/conftest.py`
- `sme_uniforme_apps/proponentes/tests/test_tipo_documento/test_tipo_documento_model.py`
- `sme_uniforme_apps/proponentes/tests/test_tipo_documento/test_tipo_documento_serializer.py`
- `sme_uniforme_apps/proponentes/tests/test_anexo/test_endpoint.py`
- `sme_uniforme_apps/proponentes/tests/test_loja/test_model.py`
- `sme_uniforme_apps/proponentes/tests/test_loja/test_serializers.py`
- `sme_uniforme_apps/proponentes/tests/test_loja/test_endpoint.py`
- `sme_uniforme_apps/proponentes/tests/test_proponente/test_proponentes_endpoint.py`

Comando executado:

```bash
docker compose -f docker-compose-dev.yml exec -T web pytest -q \
  sme_uniforme_apps/proponentes/tests/test_tipo_documento \
  sme_uniforme_apps/proponentes/tests/test_anexo \
  sme_uniforme_apps/proponentes/tests/test_loja \
  sme_uniforme_apps/proponentes/tests/test_proponente/test_proponentes_endpoint.py
```

Resultado:

- `56 passed`
- `0 failed`

### Frontend nos testes

Cobertura adicionada e ajustada para validar:

- regra centralizada de aceite de arquivos;
- comportamento do componente compartilhado de upload;
- remoção do comprovante de endereço no cadastro público;
- remoção do comprovante de endereço na edição logada;
- atualização do snapshot do componente de upload.

Arquivos de teste impactados:

- `src/helpers/fileUpload.test.js`
- `src/components/Input/FileUpload.test.js`
- `src/components/Input/__snapshots__/FileUpload.test.js.snap`
- `src/screens/CadastroEmpresa/LojaFisica.test.js`
- `src/screens/AreaLogada/DadosEmpresaLogado/Cadastro/components/DadosLoja/index.test.jsx`

Comando executado:

```bash
docker compose -f docker-compose-dev.yml exec frontend npm test -- --runTestsByPath src/helpers/fileUpload.test.js src/components/Input/FileUpload.test.js src/screens/CadastroEmpresa/LojaFisica.test.js src/screens/AreaLogada/DadosEmpresaLogado/Cadastro/components/DadosLoja/index.test.jsx --watchAll=false
```

Resultado:

- `4` suites passaram
- `7` testes passaram
- `1` snapshot passou

## 📋 Checklist funcional

- Validar no Admin que `TipoDocumento` exige `identificador` e aceita busca por esse campo.
- Validar no Admin e na API que anexos do proponente aceitam apenas PDF.
- Validar no Admin e na API que a fachada aceita apenas PNG, JPG e JPEG.
- Validar que `comprovante_endereco` não aparece no Admin nem nas telas de cadastro e edição de loja.
- Validar que o endpoint de atualização de lojas aceita ausência de comprovante e rejeita arquivo não PDF quando ele é enviado.
- Validar em `/adm-fornecedor/anexos` e no fluxo público que as regras de upload permanecem idênticas.

## 📌 Resumo

- Esta PR alinha backend e frontend ao novo edital no fluxo de documentos do proponente.
- O impacto principal está na parametrização técnica dos tipos de documento, na remoção do comprovante de endereço da loja e no endurecimento das regras de upload.
- A implementação foi centralizada para reduzir divergência entre Admin, API, cadastro público e área logada.
