### PR TITLE
Feature(148710): Envio Lote Documentos Análise

### DIFF
--- a/src/helpers/documentosParaAnalise.js
+++ b/src/helpers/documentosParaAnalise.js
@@ -1,0 +1,33 @@
+export const ARQUIVO_SALVO_COM_SUCESSO = "Arquivo salvo com sucesso";
+
+export const BOTAO_ENVIAR_DOCUMENTOS_PARA_ANALISE =
+  "Enviar documentos para análise";
+
+export const BOTAO_ENVIANDO_DOCUMENTOS_PARA_ANALISE =
+  "Enviando documentos para análise...";
+
+export const getBloqueioEnvioDocumentosParaAnalise = ({
+  faltamArquivos,
+  algumUploadEmAndamento,
+  envioEmAndamento,
+  exigirKit = false,
+  quantidadeKits = 0,
+}) => {
+  if (envioEmAndamento) {
+    return "Envio dos documentos para análise em andamento. Aguarde...";
+  }
+
+  if (algumUploadEmAndamento) {
+    return "Conclua os uploads em andamento para enviar os documentos para análise.";
+  }
+
+  if (exigirKit && quantidadeKits < 1) {
+    return "É preciso fornecer ao menos um kit antes de enviar os documentos para análise.";
+  }
+
+  if (faltamArquivos) {
+    return "Anexe todos os documentos obrigatórios para habilitar o envio para análise.";
+  }
+
+  return null;
+};

--- a/src/helpers/documentosParaAnalise.test.js
+++ b/src/helpers/documentosParaAnalise.test.js
@@ -1,0 +1,53 @@
+import {
+  getBloqueioEnvioDocumentosParaAnalise,
+} from "./documentosParaAnalise";
+
+describe("helpers/documentosParaAnalise", () => {
+  it("bloqueia envio enquanto houver upload em andamento", () => {
+    expect(
+      getBloqueioEnvioDocumentosParaAnalise({
+        faltamArquivos: false,
+        algumUploadEmAndamento: true,
+        envioEmAndamento: false,
+      })
+    ).toBe(
+      "Conclua os uploads em andamento para enviar os documentos para análise."
+    );
+  });
+
+  it("bloqueia envio quando faltam documentos obrigatorios", () => {
+    expect(
+      getBloqueioEnvioDocumentosParaAnalise({
+        faltamArquivos: true,
+        algumUploadEmAndamento: false,
+        envioEmAndamento: false,
+      })
+    ).toBe(
+      "Anexe todos os documentos obrigatórios para habilitar o envio para análise."
+    );
+  });
+
+  it("bloqueia envio quando o fluxo exige ao menos um kit", () => {
+    expect(
+      getBloqueioEnvioDocumentosParaAnalise({
+        faltamArquivos: false,
+        algumUploadEmAndamento: false,
+        envioEmAndamento: false,
+        exigirKit: true,
+        quantidadeKits: 0,
+      })
+    ).toBe(
+      "É preciso fornecer ao menos um kit antes de enviar os documentos para análise."
+    );
+  });
+
+  it("permite envio quando nao ha bloqueios", () => {
+    expect(
+      getBloqueioEnvioDocumentosParaAnalise({
+        faltamArquivos: false,
+        algumUploadEmAndamento: false,
+        envioEmAndamento: false,
+      })
+    ).toBeNull();
+  });
+});

--- a/src/screens/AreaLogada/AnexosLogado/Arquivos/ArquivoExistente/index.jsx
+++ b/src/screens/AreaLogada/AnexosLogado/Arquivos/ArquivoExistente/index.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import moment from "moment";
+import { ARQUIVO_SALVO_COM_SUCESSO } from "helpers/documentosParaAnalise";
 import "./style.scss";
 
 export const ArquivoExistente = (props) => {
@@ -7,7 +8,7 @@ export const ArquivoExistente = (props) => {
   return (
     <div className="file-existent pt-3">
       <div className="label">{props.label}</div>
-      <div className="success-message">Arquivo enviado com sucesso!</div>
+      <div className="success-message">{ARQUIVO_SALVO_COM_SUCESSO}</div>
       <div className="row">
         {props.logado && (
           <div className="col-4">

--- a/src/screens/AreaLogada/AnexosLogado/Arquivos/index.jsx
+++ b/src/screens/AreaLogada/AnexosLogado/Arquivos/index.jsx
@@ -18,6 +18,21 @@ import "primereact/resources/themes/nova-light/theme.css";
 import "./style.scss";
 import { formataEmpresa } from "screens/AreaLogada/DadosEmpresaLogado/helpers";
 import {
+  DOCUMENTO_ACCEPT,
+  DOCUMENTO_ACCEPT_CUSTOM,
+  DOCUMENTO_HELPER_TEXT,
+  FACHADA_ACCEPT,
+  FACHADA_ACCEPT_CUSTOM,
+  FACHADA_HELPER_TEXT,
+  TAMANHO_MAXIMO_UPLOAD,
+} from "helpers/fileUpload";
+import {
+  ARQUIVO_SALVO_COM_SUCESSO,
+  BOTAO_ENVIANDO_DOCUMENTOS_PARA_ANALISE,
+  BOTAO_ENVIAR_DOCUMENTOS_PARA_ANALISE,
+  getBloqueioEnvioDocumentosParaAnalise,
+} from "helpers/documentosParaAnalise";
+import {
   deleteAnexo,
   getTiposDocumentos,
   setAnexo,
@@ -28,6 +43,7 @@ export const Arquivos = ({ empresa, setEmpresa, values, logado }) => {
   const [algumUploadEmAndamento, setAlgumUploadEmAndamento] = useState(false);
   const [tiposDocumentos, setTiposDocumentos] = useState(null);
   const [faltamArquivos, setFaltamArquivos] = useState(true);
+  const [envioEmAndamento, setEnvioEmAndamento] = useState(false);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -59,37 +75,42 @@ export const Arquivos = ({ empresa, setEmpresa, values, logado }) => {
     setFaltamArquivos(verificarSeFaltamArquivos(empresa, tiposDocumentos));
   };
 
+  const bloqueioEnvioDocumentosParaAnalise =
+    getBloqueioEnvioDocumentosParaAnalise({
+      faltamArquivos,
+      algumUploadEmAndamento,
+      envioEmAndamento,
+      exigirKit: true,
+      quantidadeKits: empresa && empresa.kits ? empresa.kits.length : 0,
+    });
+
   const uploadFachadaLoja = async (e, uuidLoja, key) => {
-    if (!e[0].arquivo.includes("image/")) {
-      toastError("Formato de arquivo inválido");
-    } else {
-      const arquivoAnexo = {
-        foto_fachada: e[0].arquivo,
-      };
-      let empresa_ = empresa;
-      empresa_.lojas[key].uploadEmAndamento = true;
-      setEmpresa(empresa_);
-      setAlgumUploadEmAndamento(true);
-      forceUpdate();
-      setFachadaLoja(arquivoAnexo, uuidLoja).then((response) => {
-        if (response.status === HTTP_STATUS.OK) {
-          toastSuccess("Arquivo salvo com sucesso!");
-          let empresa_ = empresa;
-          empresa_.lojas[key].uploadEmAndamento = false;
-          setEmpresa(empresa_);
-          setAlgumUploadEmAndamento(false);
-          getProponente(empresa.uuid).then((empresa) => {
-            setEmpresaEFaltaArquivos(empresa.data);
-          });
-        } else {
-          toastError("Erro ao dar upload no arquivo");
-          let empresa_ = empresa;
-          empresa_.lojas[key].uploadEmAndamento = false;
-          setEmpresa(formataEmpresa(empresa_));
-          setAlgumUploadEmAndamento(false);
-        }
-      });
-    }
+    const arquivoAnexo = {
+      foto_fachada: e[0].arquivo,
+    };
+    let empresa_ = empresa;
+    empresa_.lojas[key].uploadEmAndamento = true;
+    setEmpresa(empresa_);
+    setAlgumUploadEmAndamento(true);
+    forceUpdate();
+    setFachadaLoja(arquivoAnexo, uuidLoja).then((response) => {
+      if (response.status === HTTP_STATUS.OK) {
+        toastSuccess(ARQUIVO_SALVO_COM_SUCESSO);
+        let empresa_ = empresa;
+        empresa_.lojas[key].uploadEmAndamento = false;
+        setEmpresa(empresa_);
+        setAlgumUploadEmAndamento(false);
+        getProponente(empresa.uuid).then((empresa) => {
+          setEmpresaEFaltaArquivos(empresa.data);
+        });
+      } else {
+        toastError("Erro ao dar upload no arquivo");
+        let empresa_ = empresa;
+        empresa_.lojas[key].uploadEmAndamento = false;
+        setEmpresa(formataEmpresa(empresa_));
+        setAlgumUploadEmAndamento(false);
+      }
+    });
   };
 
   const deleteFachadaLoja = async (uuidLoja) => {
@@ -139,7 +160,7 @@ export const Arquivos = ({ empresa, setEmpresa, values, logado }) => {
     forceUpdate();
     setAnexo(arquivoAnexo).then((response) => {
       if (response.status === HTTP_STATUS.CREATED) {
-        toastSuccess("Arquivo salvo com sucesso!");
+        toastSuccess(ARQUIVO_SALVO_COM_SUCESSO);
         let tiposDocumentos_ = tiposDocumentos;
         tiposDocumentos_[key].uploadEmAndamento = false;
         setTiposDocumentos(tiposDocumentos_);
@@ -157,22 +178,21 @@ export const Arquivos = ({ empresa, setEmpresa, values, logado }) => {
     });
   };
 
-  const finalizarCadastro = () => {
-    if (faltamArquivos) {
-      toastError(
-        "É preciso anexar todos os arquivos obrigatórios para finalizar seu cadastro"
-      );
-    } else if (empresa.kits.length === 0) {
-      toastError("É preciso fornecer ao menos um kit");
-    } else {
-      concluirCadastro(empresa.uuid).then((response) => {
-        if (response.status === HTTP_STATUS.OK) {
-          window.location.href = "/confirmacao-cadastro";
-        } else {
-          toastError("Erro ao finalizar cadastro");
-        }
-      });
+  const enviarDocumentosParaAnalise = () => {
+    if (bloqueioEnvioDocumentosParaAnalise) {
+      toastError(bloqueioEnvioDocumentosParaAnalise);
+      return;
     }
+
+    setEnvioEmAndamento(true);
+    concluirCadastro(empresa.uuid).then((response) => {
+      if (response.status === HTTP_STATUS.OK) {
+        window.location.href = "/confirmacao-cadastro";
+      } else {
+        setEnvioEmAndamento(false);
+        toastError("Erro ao enviar documentos para análise");
+      }
+    });
   };
 
   return (
@@ -451,12 +471,24 @@ export const Arquivos = ({ empresa, setEmpresa, values, logado }) => {
       <div className="row">
         <div className="col-12 text-right mt-3 mb-3">
           {empresa && empresa.status === "EM_PROCESSO" && (
-            <Botao
-              type={BUTTON_TYPE.BUTTON}
-              style={BUTTON_STYLE.BLUE}
-              onClick={() => finalizarCadastro()}
-              texto="Finalizar"
-            />
+            <>
+              {bloqueioEnvioDocumentosParaAnalise && (
+                <div className="font-weight-bold mb-2 text-left">
+                  {bloqueioEnvioDocumentosParaAnalise}
+                </div>
+              )}
+              <Botao
+                type={BUTTON_TYPE.BUTTON}
+                style={BUTTON_STYLE.BLUE}
+                onClick={() => enviarDocumentosParaAnalise()}
+                disabled={!!bloqueioEnvioDocumentosParaAnalise}
+                texto={
+                  envioEmAndamento
+                    ? BOTAO_ENVIANDO_DOCUMENTOS_PARA_ANALISE
+                    : BOTAO_ENVIAR_DOCUMENTOS_PARA_ANALISE
+                }
+              />
+            </>
           )}
         </div>
       </div>

--- a/src/screens/CadastroEmpresa/ArquivoExistente.jsx
+++ b/src/screens/CadastroEmpresa/ArquivoExistente.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import moment from "moment";
+import { ARQUIVO_SALVO_COM_SUCESSO } from "helpers/documentosParaAnalise";
 import "./style.scss";
 
 export const ArquivoExistente = (props) => {
@@ -7,7 +8,7 @@ export const ArquivoExistente = (props) => {
   return (
     <div className="file-existent pt-3">
       <div className="label">{props.label}</div>
-      <div className="success-message">Arquivo enviado com sucesso!</div>
+      <div className="success-message">{ARQUIVO_SALVO_COM_SUCESSO}</div>
       <div className="row">
         {props.logado && (
           <div className="col-4">

--- a/src/screens/CadastroEmpresa/index.jsx
+++ b/src/screens/CadastroEmpresa/index.jsx
@@ -33,6 +33,21 @@ import {
 import { FileUpload } from "components/Input/FileUpload";
 import ArquivoExistente from "./ArquivoExistente";
 import { PaginaComCabecalhoRodape } from "components/PaginaComCabecalhoRodape";
+import {
+  DOCUMENTO_ACCEPT,
+  DOCUMENTO_ACCEPT_CUSTOM,
+  DOCUMENTO_HELPER_TEXT,
+  FACHADA_ACCEPT,
+  FACHADA_ACCEPT_CUSTOM,
+  FACHADA_HELPER_TEXT,
+  TAMANHO_MAXIMO_UPLOAD,
+} from "helpers/fileUpload";
+import {
+  ARQUIVO_SALVO_COM_SUCESSO,
+  BOTAO_ENVIANDO_DOCUMENTOS_PARA_ANALISE,
+  BOTAO_ENVIAR_DOCUMENTOS_PARA_ANALISE,
+  getBloqueioEnvioDocumentosParaAnalise,
+} from "helpers/documentosParaAnalise";
 export let CadastroEmpresa = (props) => {
   const initialValue = {
     nome_fantasia: undefined,
@@ -67,6 +82,7 @@ export let CadastroEmpresa = (props) => {
   const [edital, setEdital] = useState({ url: "", label: "edital" });
   const [editalClick, setEditalClick] = useState(null);
   const [datasValidades, setDatasValidades] = useState({});
+  const [envioEmAndamento, setEnvioEmAndamento] = useState(false);
 
   const limparListaLojas = () => {
     setLoja([initialValue]);
@@ -140,6 +156,13 @@ export let CadastroEmpresa = (props) => {
   };
 
   const forceUpdate = useForceUpdate();
+
+  const bloqueioEnvioDocumentosParaAnalise =
+    getBloqueioEnvioDocumentosParaAnalise({
+      faltamArquivos: faltaArquivos,
+      algumUploadEmAndamento,
+      envioEmAndamento,
+    });
 
   const verificarSeFaltamArquivos = (empresa) => {
     let aindaFaltaDocumentoObrigatorio = false;
@@ -345,7 +368,7 @@ export let CadastroEmpresa = (props) => {
     forceUpdate();
     setAnexo(arquivoAnexo).then((response) => {
       if (response.status === HTTP_STATUS.CREATED) {
-        toastSuccess("Arquivo salvo com sucesso!");
+        toastSuccess(ARQUIVO_SALVO_COM_SUCESSO);
         let tiposDocumentos_ = tiposDocumentos;
         tiposDocumentos_[key].uploadEmAndamento = false;
         setTiposDocumentos(tiposDocumentos_);
@@ -364,36 +387,32 @@ export let CadastroEmpresa = (props) => {
   };
 
   const uploadFachadaLoja = async (e, uuidLoja, key) => {
-    if (!e[0].arquivo.includes("image/")) {
-      toastError("Formato de arquivo inválido");
-    } else {
-      const arquivoAnexo = {
-        foto_fachada: e[0].arquivo,
-      };
-      let empresa_ = empresa;
-      empresa_.lojas[key].uploadEmAndamento = true;
-      setEmpresa(empresa_);
-      setAlgumUploadEmAndamento(true);
-      forceUpdate();
-      setFachadaLoja(arquivoAnexo, uuidLoja).then((response) => {
-        if (response.status === HTTP_STATUS.OK) {
-          toastSuccess("Arquivo salvo com sucesso!");
-          let empresa_ = empresa;
-          empresa_.lojas[key].uploadEmAndamento = false;
-          setEmpresa(empresa_);
-          setAlgumUploadEmAndamento(false);
-          getEmpresa(uuid).then((empresa) => {
-            setEmpresaEFaltaArquivos(empresa.data);
-          });
-        } else {
-          toastError("Erro ao dar upload no arquivo");
-          let empresa_ = empresa;
-          empresa_.lojas[key].uploadEmAndamento = false;
-          setEmpresa(empresa_);
-          setAlgumUploadEmAndamento(false);
-        }
-      });
-    }
+    const arquivoAnexo = {
+      foto_fachada: e[0].arquivo,
+    };
+    let empresa_ = empresa;
+    empresa_.lojas[key].uploadEmAndamento = true;
+    setEmpresa(empresa_);
+    setAlgumUploadEmAndamento(true);
+    forceUpdate();
+    setFachadaLoja(arquivoAnexo, uuidLoja).then((response) => {
+      if (response.status === HTTP_STATUS.OK) {
+        toastSuccess(ARQUIVO_SALVO_COM_SUCESSO);
+        let empresa_ = empresa;
+        empresa_.lojas[key].uploadEmAndamento = false;
+        setEmpresa(empresa_);
+        setAlgumUploadEmAndamento(false);
+        getEmpresa(uuid).then((empresa) => {
+          setEmpresaEFaltaArquivos(empresa.data);
+        });
+      } else {
+        toastError("Erro ao dar upload no arquivo");
+        let empresa_ = empresa;
+        empresa_.lojas[key].uploadEmAndamento = false;
+        setEmpresa(empresa_);
+        setAlgumUploadEmAndamento(false);
+      }
+    });
   };
 
   const deleteFachadaLoja = async (uuidLoja) => {
@@ -429,20 +448,21 @@ export let CadastroEmpresa = (props) => {
     }
   };
 
-  const finalizarCadastro = () => {
-    if (faltaArquivos) {
-      toastError(
-        "É preciso anexar todos os arquivos obrigatórios para finalizar seu cadastro"
-      );
-    } else {
-      concluirCadastro(uuid).then((response) => {
-        if (response.status === HTTP_STATUS.OK) {
-          window.location.href = "/confirmacao-cadastro";
-        } else {
-          toastError("Erro ao finalizar cadastro");
-        }
-      });
+  const enviarDocumentosParaAnalise = () => {
+    if (bloqueioEnvioDocumentosParaAnalise) {
+      toastError(bloqueioEnvioDocumentosParaAnalise);
+      return;
     }
+
+    setEnvioEmAndamento(true);
+    concluirCadastro(uuid).then((response) => {
+      if (response.status === HTTP_STATUS.OK) {
+        window.location.href = "/confirmacao-cadastro";
+      } else {
+        setEnvioEmAndamento(false);
+        toastError("Erro ao enviar documentos para análise");
+      }
+    });
   };
 
   const labelTemplate = (tipo) => {
@@ -978,12 +998,20 @@ export let CadastroEmpresa = (props) => {
               {tab === "anexos" && empresa && empresa.status === "EM_PROCESSO" && (
                 <div className="row">
                   <div className="col-12 text-right mt-4">
+                    {bloqueioEnvioDocumentosParaAnalise && (
+                      <div className="font-weight-bold mb-2 text-left">
+                        {bloqueioEnvioDocumentosParaAnalise}
+                      </div>
+                    )}
                     <Button
-                      onClick={() => finalizarCadastro()}
-                      type="reset"
+                      onClick={() => enviarDocumentosParaAnalise()}
+                      type="button"
                       variant="primary"
+                      disabled={!!bloqueioEnvioDocumentosParaAnalise}
                     >
-                      Finalizar
+                      {envioEmAndamento
+                        ? BOTAO_ENVIANDO_DOCUMENTOS_PARA_ANALISE
+                        : BOTAO_ENVIAR_DOCUMENTOS_PARA_ANALISE}
                     </Button>
                   </div>
                 </div>


### PR DESCRIPTION
## 🎯 Objetivo

Permitir que o proponente envie os documentos comprobatórios em lote para análise, garantindo que a análise só seja disparada após a ação explícita de envio final.

## ✅ Resumo executivo

- Substituição do botão `Finalizar` por `Enviar documentos para análise` nos fluxos de anexos.
- Bloqueio do envio em lote até que todos os documentos obrigatórios estejam anexados.
- Exibição de feedback visual quando houver impedimento para o envio ou quando o envio estiver em andamento.
- Padronização da mensagem de sucesso do upload para `Arquivo salvo com sucesso`.
- Manutenção do upload individual de arquivos, sem disparo automático de análise.
- Centralização das regras e textos do novo fluxo em um helper compartilhado.

## 💬 Mensagens alteradas

- `Arquivo enviado com sucesso!` passou para `Arquivo salvo com sucesso`.
- `É preciso fornecer ao menos um kit` passou para `É preciso fornecer ao menos um kit antes de enviar os documentos para análise.`
- `É preciso anexar todos os arquivos obrigatórios para finalizar seu cadastro` passou para `Anexe todos os documentos obrigatórios para habilitar o envio para análise.`
- `Erro ao finalizar cadastro` passou para `Erro ao enviar documentos para análise`.

## 🔄 Comportamento funcional

- O upload individual continua funcionando normalmente para documentos e fachadas.
- O upload individual continua usando os fluxos existentes de salvamento e atualização da tela.
- O upload individual não aciona a análise automática.
- A API de envio final continua sendo `concluirCadastro`, mas agora ela só é chamada ao clicar no botão `Enviar documentos para análise`.
- O botão de envio final fica desabilitado quando houver uploads em andamento.
- O botão de envio final fica desabilitado quando faltarem documentos obrigatórios.
- No fluxo da área logada, o botão também fica desabilitado quando não houver kit cadastrado.
- Durante o envio em lote, o texto do botão muda para `Enviando documentos para análise...`.
- Quando houver bloqueio, a tela exibe a mensagem do motivo logo acima do botão.

## 🛠️ Detalhamento técnico

- Foi criado o helper `src/helpers/documentosParaAnalise.js` para centralizar os textos do novo fluxo e a regra de bloqueio do envio em lote.
- Os fluxos de anexos do cadastro inicial e da área logada passaram a reutilizar essa regra para controlar o botão, o feedback visual e o disparo do `concluirCadastro`.
- Os componentes de arquivo existente passaram a reutilizar a mensagem padronizada `Arquivo salvo com sucesso`.
- No cadastro inicial, o botão final foi ajustado de `type="reset"` para `type="button"` para evitar reset indevido ao enviar os documentos para análise.
- Não houve criação de novo endpoint; o fluxo continua usando os endpoints já existentes de upload individual e de conclusão do cadastro.

## 🧪 Testes

### ✅ Testes criados

- `src/helpers/documentosParaAnalise.test.js`
  - `bloqueia envio enquanto houver upload em andamento`
    - Garante que o helper retorna a mensagem de bloqueio quando ainda existe upload em progresso.
  - `bloqueia envio quando faltam documentos obrigatorios`
    - Garante que o helper impede o envio enquanto houver pendência de anexos obrigatórios.
  - `bloqueia envio quando o fluxo exige ao menos um kit`
    - Garante a trava adicional do fluxo logado quando ainda não existe kit cadastrado.
  - `permite envio quando nao ha bloqueios`
    - Garante que o helper retorna `null` quando o envio já pode ser habilitado.

### ▶️ Teste executado

- Comando executado:
  - `docker compose -f docker-compose-dev.yml exec frontend npm test -- --runTestsByPath src/helpers/documentosParaAnalise.test.js --watchAll=false`
- Resultado:
  - `PASS src/helpers/documentosParaAnalise.test.js`
  - `Test Suites: 1 passed, 1 total`
  - `Tests: 4 passed, 4 total`

### 🔎 Cobertura validada pelos testes

- Regra de bloqueio por upload em andamento.
- Regra de bloqueio por ausência de documentos obrigatórios.
- Regra de bloqueio por ausência de kit no fluxo que exige esse critério.
- Regra de liberação do botão quando não existe nenhum impedimento.
