### PR TITLE
Feature(150311) Suporte para CNPJ Alfanumérico e Comprovante de Endereço Para Cada Loja

### DIFF
--- a/src/helpers/fieldValidators.js
+++ b/src/helpers/fieldValidators.js
@@ -1,5 +1,5 @@
-import { validate } from "cnpj";
 import { between } from "./helpers";
+import { validarCNPJ as validarDocumentoCNPJ } from "./utils";
 
 export const required = (value) =>
   value !== undefined ? undefined : "Campo obrigatório";
@@ -75,7 +75,7 @@ export const validaUF = (value) => {
 };
 
 export const validaCNPJ = (value) =>
-  validate(value) ? undefined : "Necessário um CNPJ Valido!";
+  validarDocumentoCNPJ(value) ? undefined : "Necessário um CNPJ Valido!";
 
 export const validaTelefone = (value) => {
   let numero = value

--- a/src/helpers/fieldValidators.test.js
+++ b/src/helpers/fieldValidators.test.js
@@ -4,7 +4,8 @@ import {
   prefeituraEmail,
   numericInteger,
   alphaNumeric,
-  phoneNumber
+  phoneNumber,
+  validaCNPJ,
 } from "helpers/fieldValidators";
 
 describe("test Validators", () => {
@@ -51,6 +52,26 @@ describe("test Validators", () => {
   it("phoneNumber is not valid", () => {
     expect(phoneNumber("12345678")).toBe(
       "Invalid phone number, must be 10 digits"
+    );
+  });
+
+  it("validaCNPJ aceita CNPJ numerico legado valido", () => {
+    expect(validaCNPJ("58.578.683/0001-49")).toBeUndefined();
+  });
+
+  it("validaCNPJ aceita CNPJ alfanumerico valido", () => {
+    expect(validaCNPJ("12.ABC.345/01DE-35")).toBeUndefined();
+  });
+
+  it("validaCNPJ rejeita CNPJ alfanumerico com DV invalido", () => {
+    expect(validaCNPJ("12.ABC.345/01DE-67")).toBe(
+      "Necessário um CNPJ Valido!"
+    );
+  });
+
+  it("validaCNPJ rejeita CNPJ numerico legado invalido", () => {
+    expect(validaCNPJ("58.578.683/0001-40")).toBe(
+      "Necessário um CNPJ Valido!"
     );
   });
 });

--- a/src/helpers/fileUpload.test.js
+++ b/src/helpers/fileUpload.test.js
@@ -28,4 +28,12 @@ describe("helpers/fileUpload", () => {
 
     expect(isAcceptedFile(file, FACHADA_ACCEPT_CUSTOM)).toBe(true);
   });
+
+  it("rejeita pdf para fachada", () => {
+    const file = new File(["dummy content"], "fachada.pdf", {
+      type: "application/pdf",
+    });
+
+    expect(isAcceptedFile(file, FACHADA_ACCEPT_CUSTOM)).toBe(false);
+  });
 });

--- a/src/helpers/lojasPayload.js
+++ b/src/helpers/lojasPayload.js
@@ -23,6 +23,7 @@ export const montarPayloadAtualizaLojas = (
   })),
   lojas: (empresa.lojas || []).map((loja) => {
     const payloadLoja = {
+      id: loja.id,
       uuid: loja.uuid,
       nome_fantasia: loja.nome_fantasia,
       cep: loja.cep,
@@ -34,8 +35,6 @@ export const montarPayloadAtualizaLojas = (
       uf: loja.uf || "SP",
       telefone: loja.telefone,
       site: loja.site || "",
-      foto_fachada: loja.foto_fachada || null,
-      comprovante_endereco: loja.comprovante_endereco || null,
     };
 
     if (loja.uuid === lojaUuid) {

--- a/src/helpers/lojasPayload.js
+++ b/src/helpers/lojasPayload.js
@@ -1,0 +1,47 @@
+const normalizarValorOferta = (preco) =>
+  parseFloat(String(preco || 0).replace(",", "."));
+
+export const montarPayloadAtualizaLojas = (
+  empresa,
+  lojaUuid,
+  campoArquivo,
+  valorArquivo
+) => ({
+  uuid: empresa.uuid,
+  cnpj: empresa.cnpj,
+  razao_social: empresa.razao_social,
+  end_logradouro: empresa.end_logradouro,
+  end_cidade: empresa.end_cidade,
+  end_uf: empresa.end_uf,
+  end_cep: empresa.end_cep,
+  telefone: empresa.telefone,
+  email: empresa.email,
+  responsavel: empresa.responsavel,
+  ofertas_de_uniformes: (empresa.ofertas_de_uniformes || []).map((oferta) => ({
+    nome: oferta.nome,
+    valor: normalizarValorOferta(oferta.preco),
+  })),
+  lojas: (empresa.lojas || []).map((loja) => {
+    const payloadLoja = {
+      uuid: loja.uuid,
+      nome_fantasia: loja.nome_fantasia,
+      cep: loja.cep,
+      endereco: loja.endereco,
+      bairro: loja.bairro,
+      numero: loja.numero,
+      complemento: loja.complemento || "",
+      cidade: loja.cidade || "São Paulo",
+      uf: loja.uf || "SP",
+      telefone: loja.telefone,
+      site: loja.site || "",
+      foto_fachada: loja.foto_fachada || null,
+      comprovante_endereco: loja.comprovante_endereco || null,
+    };
+
+    if (loja.uuid === lojaUuid) {
+      payloadLoja[campoArquivo] = valorArquivo;
+    }
+
+    return payloadLoja;
+  }),
+});

--- a/src/helpers/lojasPayload.test.js
+++ b/src/helpers/lojasPayload.test.js
@@ -1,0 +1,66 @@
+import { montarPayloadAtualizaLojas } from "./lojasPayload";
+
+describe("helpers/lojasPayload", () => {
+  it("monta payload de atualizacao com comprovante apenas para a loja alterada", () => {
+    const payload = montarPayloadAtualizaLojas(
+      {
+        uuid: "proponente-1",
+        cnpj: "12.ABC.345/01DE-35",
+        razao_social: "Empresa Teste",
+        end_logradouro: "Rua Teste",
+        end_cidade: "São Paulo",
+        end_uf: "SP",
+        end_cep: "01000-000",
+        telefone: "(11) 99999-9999",
+        email: "teste@example.com",
+        responsavel: "Responsavel Teste",
+        ofertas_de_uniformes: [
+          {
+            nome: "Uniforme Padrão",
+            preco: "1.01",
+          },
+        ],
+        lojas: [
+          {
+            uuid: "loja-1",
+            nome_fantasia: "Loja 1",
+            cep: "01000-000",
+            endereco: "Rua A",
+            bairro: "Centro",
+            numero: "10",
+            complemento: "",
+            telefone: "(11) 99999-9999",
+            site: "",
+          },
+          {
+            uuid: "loja-2",
+            nome_fantasia: "Loja 2",
+            cep: "02000-000",
+            endereco: "Rua B",
+            bairro: "Bairro",
+            numero: "20",
+            complemento: "Sala 1",
+            telefone: "(11) 98888-7777",
+            site: "site.test",
+          },
+        ],
+      },
+      "loja-2",
+      "comprovante_endereco",
+      "data:application/pdf/pdf;base64,ABC"
+    );
+
+    expect(payload.ofertas_de_uniformes).toEqual([
+      {
+        nome: "Uniforme Padrão",
+        valor: 1.01,
+      },
+    ]);
+    expect(payload.lojas[0].comprovante_endereco).toBeNull();
+    expect(payload.lojas[1].comprovante_endereco).toBe(
+      "data:application/pdf/pdf;base64,ABC"
+    );
+    expect(payload.lojas[1].cidade).toBe("São Paulo");
+    expect(payload.lojas[1].uf).toBe("SP");
+  });
+});

--- a/src/helpers/lojasPayload.test.js
+++ b/src/helpers/lojasPayload.test.js
@@ -22,6 +22,7 @@ describe("helpers/lojasPayload", () => {
         ],
         lojas: [
           {
+            id: 1,
             uuid: "loja-1",
             nome_fantasia: "Loja 1",
             cep: "01000-000",
@@ -33,6 +34,7 @@ describe("helpers/lojasPayload", () => {
             site: "",
           },
           {
+            id: 2,
             uuid: "loja-2",
             nome_fantasia: "Loja 2",
             cep: "02000-000",
@@ -56,10 +58,14 @@ describe("helpers/lojasPayload", () => {
         valor: 1.01,
       },
     ]);
-    expect(payload.lojas[0].comprovante_endereco).toBeNull();
+    expect(payload.lojas[0].id).toBe(1);
+    expect(payload.lojas[0].comprovante_endereco).toBeUndefined();
+    expect(payload.lojas[0].foto_fachada).toBeUndefined();
+    expect(payload.lojas[1].id).toBe(2);
     expect(payload.lojas[1].comprovante_endereco).toBe(
       "data:application/pdf/pdf;base64,ABC"
     );
+    expect(payload.lojas[1].foto_fachada).toBeUndefined();
     expect(payload.lojas[1].cidade).toBe("São Paulo");
     expect(payload.lojas[1].uf).toBe("SP");
   });

--- a/src/helpers/textMask.js
+++ b/src/helpers/textMask.js
@@ -1,21 +1,44 @@
 import { createTextMask, createNumberMask } from "redux-form-input-masks";
+import { compactarCNPJ, formatarCNPJ } from "./utils";
+
+const formatarCPF = value => {
+  const valorNumerico = String(value || "")
+    .replace(/\D/g, "")
+    .slice(0, 11);
+
+  if (valorNumerico.length <= 3) {
+    return valorNumerico;
+  }
+
+  if (valorNumerico.length <= 6) {
+    return `${valorNumerico.slice(0, 3)}.${valorNumerico.slice(3)}`;
+  }
+
+  if (valorNumerico.length <= 9) {
+    return `${valorNumerico.slice(0, 3)}.${valorNumerico.slice(
+      3,
+      6
+    )}.${valorNumerico.slice(6)}`;
+  }
+
+  return `${valorNumerico.slice(0, 3)}.${valorNumerico.slice(
+    3,
+    6
+  )}.${valorNumerico.slice(6, 9)}-${valorNumerico.slice(9)}`;
+};
 
 export const fieldCPF_CNPJ = value => {
-  if (value.length <= 11) {
-    return value
-      .replace(/\D/g, "")
-      .replace(/(\d{3})(\d{3})(\d{3})(\d{2})/g, "$1.$2.$3-$4");
-  } else {
-    return value
-      .replace(/\D/g, "")
-      .replace(/(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/g, "$1.$2.$3/$4-$5");
+  const valorCompactado = compactarCNPJ(value);
+
+  if (!/[A-Z]/.test(valorCompactado) && valorCompactado.length <= 11) {
+    return formatarCPF(value);
   }
+
+  return formatarCNPJ(value);
 };
 
 export const fieldCNPJ = value => {
-    return value
-      .replace(/\D/g, "")
-      .replace(/(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/g, "$1.$2.$3/$4-$5");
+    return formatarCNPJ(value);
 };
 
 export const fieldMoney = createNumberMask({

--- a/src/helpers/textMask.test.js
+++ b/src/helpers/textMask.test.js
@@ -1,4 +1,4 @@
-import { fieldCPF_CNPJ } from "helpers/textMask";
+import { fieldCPF_CNPJ, fieldCNPJ } from "helpers/textMask";
 
 describe("test fieldCPF_CNPJ", () => {
   it("fieldCPF_CNPJ Format CPF", () => {
@@ -7,5 +7,13 @@ describe("test fieldCPF_CNPJ", () => {
 
   it("fieldCPF_CNPJ Format CNPJ", () => {
     expect(fieldCPF_CNPJ("58578683000149")).toBe("58.578.683/0001-49");
+  });
+
+  it("fieldCNPJ formata CNPJ alfanumerico em maiusculo", () => {
+    expect(fieldCNPJ("12abc34501de35")).toBe("12.ABC.345/01DE-35");
+  });
+
+  it("fieldCPF_CNPJ mantem compatibilidade com CNPJ alfanumerico", () => {
+    expect(fieldCPF_CNPJ("ab123cd456ef80")).toBe("AB.123.CD4/56EF-80");
   });
 });

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -40,6 +40,46 @@ export const getError = obj => {
   return result;
 };
 
+export const compactarCNPJ = cnpj =>
+  String(cnpj || "")
+    .toUpperCase()
+    .replace(/[^0-9A-Z]/g, "")
+    .slice(0, 14);
+
+export const formatarCNPJ = cnpj => {
+  const valorCompactado = compactarCNPJ(cnpj);
+
+  if (valorCompactado.length <= 2) {
+    return valorCompactado;
+  }
+
+  if (valorCompactado.length <= 5) {
+    return `${valorCompactado.slice(0, 2)}.${valorCompactado.slice(2)}`;
+  }
+
+  if (valorCompactado.length <= 8) {
+    return `${valorCompactado.slice(0, 2)}.${valorCompactado.slice(
+      2,
+      5
+    )}.${valorCompactado.slice(5)}`;
+  }
+
+  if (valorCompactado.length <= 12) {
+    return `${valorCompactado.slice(0, 2)}.${valorCompactado.slice(
+      2,
+      5
+    )}.${valorCompactado.slice(5, 8)}/${valorCompactado.slice(8)}`;
+  }
+
+  return `${valorCompactado.slice(0, 2)}.${valorCompactado.slice(
+    2,
+    5
+  )}.${valorCompactado.slice(5, 8)}/${valorCompactado.slice(
+    8,
+    12
+  )}-${valorCompactado.slice(12)}`;
+};
+
 export const validarCPF = cpf => {
   cpf = cpf.replace(/[^\d]+/g, "");
   if (cpf === "") return false;
@@ -74,9 +114,7 @@ export const validarCPF = cpf => {
   return true;
 };
 
-export const validarCNPJ = cnpj => {
-  cnpj = cnpj.replace(/[^\d]+/g, "");
-
+const validarSequenciaNumericaRepetida = cnpj => {
   if (cnpj === "") return false;
 
   if (cnpj.length !== 14) return false;
@@ -96,32 +134,45 @@ export const validarCNPJ = cnpj => {
   )
     return false;
 
-  // Valida DVs
-  let i;
-  let tamanho = cnpj.length - 2;
-  let numeros = cnpj.substring(0, tamanho);
-  let digitos = cnpj.substring(tamanho);
-  let soma = 0;
-  let pos = tamanho - 7;
-  for (i = tamanho; i >= 1; i--) {
-    soma += numeros.charAt(tamanho - i) * pos--;
-    if (pos < 2) pos = 9;
-  }
-  let resultado = soma % 11 < 2 ? 0 : 11 - (soma % 11);
-  if (resultado !== parseInt(digitos.charAt(0))) return false;
-
-  tamanho = tamanho + 1;
-  numeros = cnpj.substring(0, tamanho);
-  soma = 0;
-  pos = tamanho - 7;
-  for (i = tamanho; i >= 1; i--) {
-    soma += numeros.charAt(tamanho - i) * pos--;
-    if (pos < 2) pos = 9;
-  }
-  resultado = soma % 11 < 2 ? 0 : 11 - (soma % 11);
-  if (resultado !== parseInt(digitos.charAt(1))) return false;
-
   return true;
+};
+
+const valorCaracterCNPJ = caractere => caractere.charCodeAt(0) - 48;
+
+const calcularDigitoCNPJ = (base, pesos) => {
+  const soma = base.split("").reduce((acumulado, caractere, indice) => {
+    return acumulado + valorCaracterCNPJ(caractere) * pesos[indice];
+  }, 0);
+  const modulo = soma % 11;
+
+  return modulo < 2 ? 0 : 11 - modulo;
+};
+
+export const validarCNPJ = cnpj => {
+  const valorCompactado = compactarCNPJ(cnpj);
+
+  if (!/^[A-Z0-9]{12}\d{2}$/.test(valorCompactado)) {
+    return false;
+  }
+
+  if (
+    /^\d{14}$/.test(valorCompactado) &&
+    !validarSequenciaNumericaRepetida(valorCompactado)
+  ) {
+    return false;
+  }
+
+  const base = valorCompactado.slice(0, 12);
+  const digitosVerificadores = valorCompactado.slice(12);
+  const primeiroDigito = calcularDigitoCNPJ(base, [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]);
+
+  if (primeiroDigito !== parseInt(digitosVerificadores.charAt(0), 10)) {
+    return false;
+  }
+
+  const segundoDigito = calcularDigitoCNPJ(`${base}${primeiroDigito}`, [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]);
+
+  return segundoDigito === parseInt(digitosVerificadores.charAt(1), 10);
 };
 
 export const hasNumber = myString => {

--- a/src/helpers/utils.test.js
+++ b/src/helpers/utils.test.js
@@ -1,4 +1,4 @@
-import { readerFile } from "helpers/utils";
+import { readerFile, validarCNPJ, compactarCNPJ, formatarCNPJ } from "helpers/utils";
 
 describe("test readerFile", () => {
   it("converte file to base64", async () => {
@@ -7,7 +7,41 @@ describe("test readerFile", () => {
     });
 
     await readerFile(file).then(v => {
-      expect(v.planta).toContain("png");
+      expect(v.arquivo).toContain("png");
     });
+  });
+});
+
+describe("test validarCNPJ", () => {
+  it("aceita CNPJ numerico legado valido", () => {
+    expect(validarCNPJ("58.578.683/0001-49")).toBe(true);
+  });
+
+  it("aceita CNPJ alfanumerico valido", () => {
+    expect(validarCNPJ("12.ABC.345/01DE-35")).toBe(true);
+  });
+
+  it("rejeita CNPJ alfanumerico com DV invalido", () => {
+    expect(validarCNPJ("12.ABC.345/01DE-67")).toBe(false);
+  });
+
+  it("rejeita CNPJ numerico legado invalido", () => {
+    expect(validarCNPJ("58.578.683/0001-40")).toBe(false);
+  });
+});
+
+describe("test compactarCNPJ", () => {
+  it("remove mascara e converte para maiusculo", () => {
+    expect(compactarCNPJ("12.ABC.345/01DE-35")).toBe("12ABC34501DE35");
+  });
+});
+
+describe("test formatarCNPJ", () => {
+  it("formata CNPJ numerico com mascara", () => {
+    expect(formatarCNPJ("58578683000149")).toBe("58.578.683/0001-49");
+  });
+
+  it("formata CNPJ alfanumerico com mascara", () => {
+    expect(formatarCNPJ("12abc34501de35")).toBe("12.ABC.345/01DE-35");
   });
 });

--- a/src/screens/AreaLogada/AnexosLogado/Arquivos/index.jsx
+++ b/src/screens/AreaLogada/AnexosLogado/Arquivos/index.jsx
@@ -9,7 +9,11 @@ import { htmlTextToDiv } from "helpers/helpers";
 import Botao from "components/Botao";
 import { BUTTON_TYPE, BUTTON_STYLE } from "components/Botao/constants";
 import { toastSuccess, toastError } from "components/Toast/dialogs";
-import { getProponente, concluirCadastro } from "services/cadastro.service";
+import {
+  getProponente,
+  concluirCadastro,
+  atualizaLojas,
+} from "services/cadastro.service";
 import { verificarSeFaltamArquivos } from "./helpers";
 import { OnChange } from "react-final-form-listeners";
 import "primeicons/primeicons.css";
@@ -32,11 +36,12 @@ import {
   BOTAO_ENVIAR_DOCUMENTOS_PARA_ANALISE,
   getBloqueioEnvioDocumentosParaAnalise,
 } from "helpers/documentosParaAnalise";
+import { montarPayloadAtualizaLojas } from "helpers/lojasPayload";
 import {
   deleteAnexo,
   getTiposDocumentos,
   setAnexo,
-  setFachadaLoja,
+  setArquivoLoja,
 } from "services/uniformes.service";
 
 export const Arquivos = ({ empresa, setEmpresa, values, logado }) => {
@@ -88,16 +93,28 @@ export const Arquivos = ({ empresa, setEmpresa, values, logado }) => {
     const arquivoAnexo = {
       foto_fachada: e[0].arquivo,
     };
-    let empresa_ = empresa;
-    empresa_.lojas[key].uploadEmAndamento = true;
+    let empresa_ = {
+      ...empresa,
+      lojas: empresa.lojas.map((lojaAtual, index) =>
+        index === key
+          ? { ...lojaAtual, uploadEmAndamento: true }
+          : lojaAtual
+      ),
+    };
     setEmpresa(empresa_);
     setAlgumUploadEmAndamento(true);
     forceUpdate();
-    setFachadaLoja(arquivoAnexo, uuidLoja).then((response) => {
+    setArquivoLoja(arquivoAnexo, uuidLoja).then((response) => {
       if (response.status === HTTP_STATUS.OK) {
         toastSuccess(ARQUIVO_SALVO_COM_SUCESSO);
-        let empresa_ = empresa;
-        empresa_.lojas[key].uploadEmAndamento = false;
+        let empresa_ = {
+          ...empresa,
+          lojas: empresa.lojas.map((lojaAtual, index) =>
+            index === key
+              ? { ...lojaAtual, uploadEmAndamento: false }
+              : lojaAtual
+          ),
+        };
         setEmpresa(empresa_);
         setAlgumUploadEmAndamento(false);
         getProponente(empresa.uuid).then((empresa) => {
@@ -105,8 +122,53 @@ export const Arquivos = ({ empresa, setEmpresa, values, logado }) => {
         });
       } else {
         toastError("Erro ao dar upload no arquivo");
-        let empresa_ = empresa;
-        empresa_.lojas[key].uploadEmAndamento = false;
+        let empresa_ = {
+          ...empresa,
+          lojas: empresa.lojas.map((lojaAtual, index) =>
+            index === key
+              ? { ...lojaAtual, uploadEmAndamento: false }
+              : lojaAtual
+          ),
+        };
+        setEmpresa(formataEmpresa(empresa_));
+        setAlgumUploadEmAndamento(false);
+      }
+    });
+  };
+
+  const uploadComprovanteLoja = async (e, uuidLoja, key) => {
+    const payload = montarPayloadAtualizaLojas(
+      empresa,
+      uuidLoja,
+      "comprovante_endereco",
+      e[0].arquivo
+    );
+    let empresa_ = {
+      ...empresa,
+      lojas: empresa.lojas.map((lojaAtual, index) =>
+        index === key
+          ? { ...lojaAtual, uploadEmAndamento: true }
+          : lojaAtual
+      ),
+    };
+    setEmpresa(empresa_);
+    setAlgumUploadEmAndamento(true);
+    forceUpdate();
+    atualizaLojas(empresa.uuid, payload).then((response) => {
+      if (response.status === HTTP_STATUS.OK) {
+        toastSuccess(ARQUIVO_SALVO_COM_SUCESSO);
+        setEmpresaEFaltaArquivos(response.data);
+        setAlgumUploadEmAndamento(false);
+      } else {
+        toastError("Erro ao dar upload no arquivo");
+        let empresa_ = {
+          ...empresa,
+          lojas: empresa.lojas.map((lojaAtual, index) =>
+            index === key
+              ? { ...lojaAtual, uploadEmAndamento: false }
+              : lojaAtual
+          ),
+        };
         setEmpresa(formataEmpresa(empresa_));
         setAlgumUploadEmAndamento(false);
       }
@@ -118,12 +180,31 @@ export const Arquivos = ({ empresa, setEmpresa, values, logado }) => {
       const arquivoAnexo = {
         foto_fachada: null,
       };
-      setFachadaLoja(arquivoAnexo, uuidLoja).then((response) => {
+      setArquivoLoja(arquivoAnexo, uuidLoja).then((response) => {
         if (response.status === HTTP_STATUS.OK) {
           toastSuccess("Arquivo excluído com sucesso!");
           getProponente(empresa.uuid).then((empresa) => {
             setEmpresaEFaltaArquivos(empresa.data);
           });
+        } else {
+          toastError("Erro ao dar excluir no arquivo");
+        }
+      });
+    }
+  };
+
+  const deleteComprovanteLoja = async (uuidLoja) => {
+    if (window.confirm("Deseja remover este anexo?")) {
+      const payload = montarPayloadAtualizaLojas(
+        empresa,
+        uuidLoja,
+        "comprovante_endereco",
+        null
+      );
+      atualizaLojas(empresa.uuid, payload).then((response) => {
+        if (response.status === HTTP_STATUS.OK) {
+          toastSuccess("Arquivo excluído com sucesso!");
+          setEmpresaEFaltaArquivos(response.data);
         } else {
           toastError("Erro ao dar excluir no arquivo");
         }
@@ -204,6 +285,7 @@ export const Arquivos = ({ empresa, setEmpresa, values, logado }) => {
             empresa.lojas.map((loja, key) => {
               return !loja.foto_fachada ? (
                 <div
+                  key={`fachada_${loja.uuid || key}`}
                   className={`${
                     algumUploadEmAndamento && !loja.uploadEmAndamento
                       ? "set-opacity"
@@ -245,7 +327,7 @@ export const Arquivos = ({ empresa, setEmpresa, values, logado }) => {
                   )}
                 </div>
               ) : (
-                <div>
+                <div key={`fachada_${loja.uuid || key}`}>
                   <ArquivoExistente
                     label={`${loja.nome_fantasia} - ${loja.endereco}`}
                     arquivo={loja.foto_fachada}
@@ -253,6 +335,79 @@ export const Arquivos = ({ empresa, setEmpresa, values, logado }) => {
                     proponenteStatus={empresa && empresa.status}
                     removeAnexo={deleteFachadaLoja}
                   />
+                </div>
+              );
+            })}
+        </div>
+      </div>
+      <div className="card w-100 mt-2">
+        <div className="card-body">
+          <div className="card-title">
+            Comprovantes de Endereço dos Pontos de Venda
+          </div>
+          {empresa &&
+            empresa.lojas.map((loja, key) => {
+              return loja.comprovante_endereco ? (
+                <div key={`comprovante_${loja.uuid || key}`}>
+                  <ArquivoExistente
+                    label={`${loja.nome_fantasia} - ${loja.endereco}`}
+                    arquivo={loja.comprovante_endereco}
+                    lojaUuid={loja.uuid}
+                    proponenteStatus={empresa && empresa.status}
+                    removeAnexo={deleteComprovanteLoja}
+                  />
+                </div>
+              ) : empresa && empresa.status !== "EM_PROCESSO" && !logado ? (
+                <div
+                  key={`comprovante_${loja.uuid || key}`}
+                  className="no-file-end-signup pt-3"
+                >
+                  <div className="label">{`${loja.nome_fantasia} - ${loja.endereco}`}</div>
+                  <div>
+                    Seu cadastro foi finalizado e você não pode mais enviar este
+                    anexo.
+                  </div>
+                </div>
+              ) : (
+                <div
+                  key={`comprovante_${loja.uuid || key}`}
+                  className={`${
+                    algumUploadEmAndamento && !loja.uploadEmAndamento
+                      ? "set-opacity"
+                      : undefined
+                  } `}
+                >
+                  <Field
+                    component={FileUpload}
+                    name={`comprovante_loja_${key}`}
+                    disabled={algumUploadEmAndamento}
+                    id={`comprovante_${key}`}
+                    key={`comprovante_${key}`}
+                    accept={DOCUMENTO_ACCEPT}
+                    acceptCustom={DOCUMENTO_ACCEPT_CUSTOM}
+                    className="form-control-file"
+                    label={`${loja.nome_fantasia} - ${loja.endereco}`}
+                    multiple={false}
+                  />
+                  <div className="campos-permitidos">
+                    {DOCUMENTO_HELPER_TEXT}
+                    <br />
+                    {TAMANHO_MAXIMO_UPLOAD}
+                  </div>
+                  <OnChange name={`comprovante_loja_${key}`}>
+                    {async (value) => {
+                      if (value && value.length > 0) {
+                        uploadComprovanteLoja(value, loja.uuid, key);
+                      }
+                    }}
+                  </OnChange>
+                  {loja.uploadEmAndamento && (
+                    <span className="font-weight-bold">
+                      {`Upload de documento em andamento. `}
+                      <span className="red-word">Aguarde</span>
+                      <span className="blink">...</span>
+                    </span>
+                  )}
                 </div>
               );
             })}
@@ -269,7 +424,7 @@ export const Arquivos = ({ empresa, setEmpresa, values, logado }) => {
                     arquivo.tipo_documento.id === tipo.id &&
                     !["REPROVADO", "VENCIDO"].includes(arquivo.status)
                 ) ? (
-                <div>
+                <div key={`documento_${tipo.id}`}>
                   <ArquivoExistente
                     label={htmlTextToDiv(tipo)}
                     arquivo={empresa.arquivos_anexos.find(
@@ -282,7 +437,7 @@ export const Arquivos = ({ empresa, setEmpresa, values, logado }) => {
                   <hr />
                 </div>
               ) : empresa && empresa.status !== "EM_PROCESSO" && !logado ? (
-                <div className="no-file-end-signup pt-3">
+                <div key={`documento_${tipo.id}`} className="no-file-end-signup pt-3">
                   <div className="label">{htmlTextToDiv(tipo)}</div>
                   <div>
                     Seu cadastro foi finalizado e você não pode mais enviar este
@@ -291,6 +446,7 @@ export const Arquivos = ({ empresa, setEmpresa, values, logado }) => {
                 </div>
               ) : (
                 <div
+                  key={`documento_${tipo.id}`}
                   className={`${
                     algumUploadEmAndamento && !tipo.uploadEmAndamento
                       ? "set-opacity"

--- a/src/screens/AreaLogada/DadosEmpresaLogado/Cadastro/components/DadosEmpresa/index.jsx
+++ b/src/screens/AreaLogada/DadosEmpresaLogado/Cadastro/components/DadosEmpresa/index.jsx
@@ -11,6 +11,7 @@ import {
   validaEmail,
   validaCNPJ,
 } from "helpers/fieldValidators";
+import { fieldCNPJ } from "helpers/textMask";
 import { toastError } from "components/Toast/dialogs";
 import { getEnderecoPorCEP } from "services/cep.service";
 import { ESTADOS } from "../../constants";
@@ -21,6 +22,7 @@ export const DadosEmpresa = ({ empresa, form, values }) => {
     APIForaDoArOuCEPNaoEncontrado,
     setAPIForaDoArOuCEPNaoEncontrado,
   ] = useState(false);
+  const empresaDesabilitada = !!empresa;
 
   return (
     <div>
@@ -29,13 +31,14 @@ export const DadosEmpresa = ({ empresa, form, values }) => {
         <div className="col-sm-6 col-12">
           <Field
             component={InputText}
-            parse={formatString("99.999.999/9999-99")}
+            customChange={fieldCNPJ}
             label="CNPJ"
             name="cnpj"
+            maxLength={18}
             required
             validate={composeValidators(required, validaCNPJ)}
             placeholder="Digite o CNPJ da Empresa"
-            disabled={empresa}
+            disabled={empresaDesabilitada}
           />
         </div>
         <div className="col-sm-6 col-12">
@@ -47,7 +50,7 @@ export const DadosEmpresa = ({ empresa, form, values }) => {
             required
             validate={composeValidators(required)}
             placeholder="Digite a Razão Social da Empresa"
-            disabled={empresa}
+            disabled={empresaDesabilitada}
           />
         </div>
       </div>
@@ -61,7 +64,7 @@ export const DadosEmpresa = ({ empresa, form, values }) => {
             required
             validate={composeValidators(required, validaCEP)}
             placeholder="Digite o CEP"
-            disabled={empresa}
+            disabled={empresaDesabilitada}
           />
           <OnChange name="end_cep">
             {async (value, previous) => {
@@ -104,7 +107,7 @@ export const DadosEmpresa = ({ empresa, form, values }) => {
             maxlength={100}
             required
             validate={required}
-            disabled={empresa || !APIForaDoArOuCEPNaoEncontrado}
+            disabled={empresaDesabilitada || !APIForaDoArOuCEPNaoEncontrado}
           />
         </div>
       </div>
@@ -117,7 +120,7 @@ export const DadosEmpresa = ({ empresa, form, values }) => {
             name="end_cidade"
             required
             validate={required}
-            disabled={empresa || !APIForaDoArOuCEPNaoEncontrado}
+            disabled={empresaDesabilitada || !APIForaDoArOuCEPNaoEncontrado}
           />
         </div>
         <div className="col-sm-2 col-12">
@@ -129,7 +132,7 @@ export const DadosEmpresa = ({ empresa, form, values }) => {
             required
             validate={required}
             naoDesabilitarPrimeiraOpcao
-            disabled={empresa || !APIForaDoArOuCEPNaoEncontrado}
+            disabled={empresaDesabilitada || !APIForaDoArOuCEPNaoEncontrado}
           />
         </div>
       </div>
@@ -144,7 +147,7 @@ export const DadosEmpresa = ({ empresa, form, values }) => {
             placeholder="Nome completo"
             required
             validate={required}
-            disabled={empresa}
+            disabled={empresaDesabilitada}
           />
         </div>
       </div>
@@ -162,7 +165,7 @@ export const DadosEmpresa = ({ empresa, form, values }) => {
             name="telefone"
             required
             type="text"
-            disabled={empresa}
+            disabled={empresaDesabilitada}
           />
         </div>
         <div className="col-sm-6 col-12">
@@ -175,7 +178,7 @@ export const DadosEmpresa = ({ empresa, form, values }) => {
             type="text"
             validate={composeValidators(required, validaEmail)}
             required
-            disabled={empresa}
+            disabled={empresaDesabilitada}
           />
         </div>
       </div>

--- a/src/screens/AreaLogada/DadosEmpresaLogado/Cadastro/components/DadosLoja/index.jsx
+++ b/src/screens/AreaLogada/DadosEmpresaLogado/Cadastro/components/DadosLoja/index.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import HTTP_STATUS from "http-status-codes";
 import { InputText } from "components/Input/InputText";
 import { Botao } from "components/Botao";
@@ -19,7 +19,9 @@ import { OnChange } from "react-final-form-listeners";
 import { toastError } from "components/Toast/dialogs";
 import { getEnderecoPorCEP } from "services/cep.service";
 import formatString from "format-string-by-pattern";
+
 export const Loja = ({ loja, fields, index, empresa, logado }) => {
+  const [apiCEPfora, setApiCEPfora] = useState(false);
   const lojaDesabilitada = !logado && !!empresa;
 
   return (
@@ -75,7 +77,7 @@ export const Loja = ({ loja, fields, index, empresa, logado }) => {
                     fields.update(index, fields.value[index]);
                   }
                 } else {
-                  return null;
+                  setApiCEPfora(true);
                 }
               }
             }}

--- a/src/screens/AreaLogada/DadosEmpresaLogado/Cadastro/components/DadosLoja/index.jsx
+++ b/src/screens/AreaLogada/DadosEmpresaLogado/Cadastro/components/DadosLoja/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import HTTP_STATUS from "http-status-codes";
 import { InputText } from "components/Input/InputText";
 import { Botao } from "components/Botao";
@@ -12,8 +12,6 @@ import {
   composeValidators,
   required,
   validaCEP,
-  validaRangeCEP,
-  validaTelefoneOuCelular,
   validaTelefoneOuCelularLength
 } from "helpers/fieldValidators";
 import formatStringByPattern from "format-string-by-pattern";
@@ -21,10 +19,8 @@ import { OnChange } from "react-final-form-listeners";
 import { toastError } from "components/Toast/dialogs";
 import { getEnderecoPorCEP } from "services/cep.service";
 import formatString from "format-string-by-pattern";
-import "./style.scss"
-
 export const Loja = ({ loja, fields, index, empresa, logado }) => {
-  const [apiCEPfora, setApiCEPfora] = useState(false);
+  const lojaDesabilitada = !logado && !!empresa;
 
   return (
     <div key={loja}>
@@ -37,7 +33,7 @@ export const Loja = ({ loja, fields, index, empresa, logado }) => {
             required
             validate={composeValidators(required)}
             placeholder="Digite o Nome Fantasia da loja"
-            disabled={!logado && empresa}
+            disabled={lojaDesabilitada}
           />
         </div>
       </div>
@@ -51,7 +47,7 @@ export const Loja = ({ loja, fields, index, empresa, logado }) => {
             required
             validate={composeValidators(required, validaCEP)}
             placeholder="Digite o CEP"
-            disabled={!logado && empresa}
+            disabled={lojaDesabilitada}
           />
           <OnChange name={`${loja}.cep`}>
             {async (value, previous) => {
@@ -79,7 +75,7 @@ export const Loja = ({ loja, fields, index, empresa, logado }) => {
                     fields.update(index, fields.value[index]);
                   }
                 } else {
-                  setApiCEPfora(true);
+                  return null;
                 }
               }
             }}
@@ -92,7 +88,7 @@ export const Loja = ({ loja, fields, index, empresa, logado }) => {
             name={`${loja}.bairro`}
             required
             validate={required}
-            disabled={!logado && empresa}
+            disabled={lojaDesabilitada}
           />
         </div>
       </div>
@@ -114,7 +110,7 @@ export const Loja = ({ loja, fields, index, empresa, logado }) => {
             name={`${loja}.numero`}
             required
             validate={composeValidators(required)}
-            disabled={!logado && empresa}
+            disabled={lojaDesabilitada}
           />
         </div>
         <div className="col-sm-4 col-12">
@@ -123,7 +119,7 @@ export const Loja = ({ loja, fields, index, empresa, logado }) => {
             maxlength={20}
             label="Complemento"
             name={`${loja}.complemento`}
-            disabled={!logado && empresa}
+            disabled={lojaDesabilitada}
           />
         </div>
       </div>
@@ -166,7 +162,7 @@ export const Loja = ({ loja, fields, index, empresa, logado }) => {
             required
             type="text"
             validate={composeValidators(required, validaTelefoneOuCelularLength)}
-            disabled={!logado && empresa}
+            disabled={lojaDesabilitada}
           />
         </div>
       </div>

--- a/src/screens/AreaLogada/DadosEmpresaLogado/Cadastro/components/DadosLoja/index.test.jsx
+++ b/src/screens/AreaLogada/DadosEmpresaLogado/Cadastro/components/DadosLoja/index.test.jsx
@@ -8,8 +8,6 @@ jest.mock("helpers/fieldValidators", () => ({
   composeValidators: jest.fn(() => undefined),
   required: jest.fn(() => undefined),
   validaCEP: jest.fn(() => undefined),
-  validaRangeCEP: jest.fn(() => undefined),
-  validaTelefoneOuCelular: jest.fn(() => undefined),
   validaTelefoneOuCelularLength: jest.fn(() => undefined),
 }));
 

--- a/src/screens/AreaLogada/DadosEmpresaLogado/helpers.js
+++ b/src/screens/AreaLogada/DadosEmpresaLogado/helpers.js
@@ -28,6 +28,7 @@ const formataPrecos = (empresa) => {
 export const formataEmpresa = (empresa) => {
   empresa = addCidadeEstadoSP(empresa);
   empresa = formataPrecos(empresa);
+  empresa.kits = empresa.ofertas_de_uniformes || [];
   return empresa;
 };
 

--- a/src/screens/AreaLogada/DadosEmpresaLogado/helpers.js
+++ b/src/screens/AreaLogada/DadosEmpresaLogado/helpers.js
@@ -43,18 +43,29 @@ export const formataPayloadLojasPrecos = (values, tiposDeUniforme) => {
       }
     });
   });
-  values.ofertas_de_uniformes = ofertas_de_uniformes;
+  const payload = {
+    ...values,
+    ofertas_de_uniformes,
+    lojas: values.lojas.map((loja) => {
+      const payloadLoja = {
+        ...loja,
+      };
 
-  // Formata comprovante de endereços de cada loja
-  values.lojas.forEach(loja =>{
+      if (
+        Array.isArray(payloadLoja.comprovante_endereco) &&
+        payloadLoja.comprovante_endereco[0]
+      ) {
+        payloadLoja.comprovante_endereco =
+          payloadLoja.comprovante_endereco[0].arquivo;
+      } else {
+        delete payloadLoja.comprovante_endereco;
+      }
 
-    if(Array.isArray(loja.comprovante_endereco) && loja.comprovante_endereco[0])
-      loja.comprovante_endereco = loja.comprovante_endereco[0].arquivo
-    else
-      delete loja.comprovante_endereco
-    
-  })
-  return values;
+      return payloadLoja;
+    }),
+  };
+
+  return payload;
 };
 
 export const validaTabelaPrecos = (values, tiposDeUniforme, limites) => {

--- a/src/screens/AreaLogada/DadosEmpresaLogado/helpers.test.js
+++ b/src/screens/AreaLogada/DadosEmpresaLogado/helpers.test.js
@@ -1,0 +1,39 @@
+import { formataPayloadLojasPrecos } from "./helpers";
+
+describe("AreaLogada/DadosEmpresaLogado/helpers", () => {
+  it("serializa comprovante_endereco novo no payload de atualizacao", () => {
+    const values = {
+      lojas: [
+        {
+          nome_fantasia: "Loja A",
+          comprovante_endereco: [
+            {
+              arquivo: "data:application/pdf/pdf;base64,ABC123",
+            },
+          ],
+        },
+      ],
+    };
+
+    const payload = formataPayloadLojasPrecos(values, []);
+
+    expect(payload.lojas[0].comprovante_endereco).toBe(
+      "data:application/pdf/pdf;base64,ABC123"
+    );
+  });
+
+  it("omite comprovante_endereco quando loja so tem URL atual", () => {
+    const values = {
+      lojas: [
+        {
+          nome_fantasia: "Loja B",
+          comprovante_endereco: "https://example.com/comprovante.pdf",
+        },
+      ],
+    };
+
+    const payload = formataPayloadLojasPrecos(values, []);
+
+    expect(payload.lojas[0].comprovante_endereco).toBeUndefined();
+  });
+});

--- a/src/screens/AreaLogada/DadosEmpresaLogado/helpers.test.js
+++ b/src/screens/AreaLogada/DadosEmpresaLogado/helpers.test.js
@@ -1,4 +1,4 @@
-import { formataPayloadLojasPrecos } from "./helpers";
+import { formataPayloadLojasPrecos, formataEmpresa } from "./helpers";
 
 describe("AreaLogada/DadosEmpresaLogado/helpers", () => {
   it("serializa comprovante_endereco novo no payload de atualizacao", () => {
@@ -35,5 +35,29 @@ describe("AreaLogada/DadosEmpresaLogado/helpers", () => {
     const payload = formataPayloadLojasPrecos(values, []);
 
     expect(payload.lojas[0].comprovante_endereco).toBeUndefined();
+  });
+
+  it("formataEmpresa cria kits a partir de ofertas_de_uniformes", () => {
+    const empresa = {
+      ofertas_de_uniformes: [
+        { nome: "Camiseta", preco: "10.00", uniforme_categoria: 1 },
+      ],
+      lojas: [],
+    };
+
+    const result = formataEmpresa(empresa);
+
+    expect(result.kits).toEqual(empresa.ofertas_de_uniformes);
+  });
+
+  it("formataEmpresa cria kits vazio quando ofertas_de_uniformes eh vazio", () => {
+    const empresa = {
+      ofertas_de_uniformes: [],
+      lojas: [],
+    };
+
+    const result = formataEmpresa(empresa);
+
+    expect(result.kits).toEqual([]);
   });
 });

--- a/src/screens/AreaLogada/DadosEmpresaLogado/helpers.test.js
+++ b/src/screens/AreaLogada/DadosEmpresaLogado/helpers.test.js
@@ -37,6 +37,21 @@ describe("AreaLogada/DadosEmpresaLogado/helpers", () => {
     expect(payload.lojas[0].comprovante_endereco).toBeUndefined();
   });
 
+  it("preserva id da loja no payload", () => {
+    const values = {
+      lojas: [
+        {
+          id: 42,
+          nome_fantasia: "Loja C",
+        },
+      ],
+    };
+
+    const payload = formataPayloadLojasPrecos(values, []);
+
+    expect(payload.lojas[0].id).toBe(42);
+  });
+
   it("formataEmpresa cria kits a partir de ofertas_de_uniformes", () => {
     const empresa = {
       ofertas_de_uniformes: [

--- a/src/screens/CadastroEmpresa/LojaFisica.jsx
+++ b/src/screens/CadastroEmpresa/LojaFisica.jsx
@@ -6,6 +6,12 @@ import {
   InputLabel,
 } from "components/Input/InputLabelRequired";
 import InputLabelRequiredMask from "components/Input/InputLabelRequiredMask";
+import { FileUpload } from "components/Input/FileUpload";
+import {
+  DOCUMENTO_ACCEPT,
+  DOCUMENTO_ACCEPT_CUSTOM,
+  DOCUMENTO_HELPER_TEXT,
+} from "helpers/fileUpload";
 
 
 const LojaFisica = (props) => {
@@ -21,6 +27,7 @@ const LojaFisica = (props) => {
   const [payload, setPayload] = useState({});
   const [erro, setErro] = useState(false);
   const [nome_fantasia, setNomeFantasia] = useState("");
+  const [comprovante_endereco, setComprovanteEndereco] = useState("");
 
   useEffect(() => {
     setTelefone(props.telefone);
@@ -33,6 +40,9 @@ const LojaFisica = (props) => {
     setComplemento(props.complemento);
     setNomeFantasia(props.nome_fantasia);
     setSite(props.site);
+    if (props.comprovante_endereco) {
+      setComprovanteEndereco(props.comprovante_endereco);
+    }
   }, [props]);
 
   const buscaCep = async (value) => {
@@ -267,6 +277,54 @@ const LojaFisica = (props) => {
           props.onUpdate({ ...payload, site: valor }, props.chave);
         }}
       />
+      <Row className="mt-2">
+        <Col>
+          {comprovante_endereco && typeof comprovante_endereco === "string" && (
+            <div className="pb-2">
+              <span className="font-weight-bold">
+                Comprovante de endereço atual: {" "}
+              </span>
+              <a target="blank" href={comprovante_endereco} rel="noopener noreferrer">
+                Visualizar arquivo
+              </a>
+            </div>
+          )}
+          <FileUpload
+            input={{
+              onChange: (data) => {
+                if (data && data.length > 0) {
+                  setComprovanteEndereco(data[0].arquivo);
+                  setPayload({ ...payload, comprovante_endereco: data[0].arquivo });
+                  props.onUpdate(
+                    { ...payload, comprovante_endereco: data[0].arquivo },
+                    props.chave
+                  );
+                } else {
+                  setComprovanteEndereco("");
+                  setPayload({ ...payload, comprovante_endereco: undefined });
+                  props.onUpdate(
+                    { ...payload, comprovante_endereco: undefined },
+                    props.chave
+                  );
+                }
+              },
+              value: [],
+            }}
+            label="Comprovante de endereço do ponto de venda"
+            accept={DOCUMENTO_ACCEPT}
+            acceptCustom={DOCUMENTO_ACCEPT_CUSTOM}
+            multiple={false}
+            disabled={props.empresa}
+            meta={{ touched: false, error: null }}
+            esconderAsterisco
+          />
+          <div className="campos-permitidos">
+            {DOCUMENTO_HELPER_TEXT}
+            <br />
+            Tamanho máximo: 5 MB
+          </div>
+        </Col>
+      </Row>
     </Fragment>
   );
 };

--- a/src/screens/CadastroEmpresa/LojaFisica.jsx
+++ b/src/screens/CadastroEmpresa/LojaFisica.jsx
@@ -1,5 +1,5 @@
 import axios from "axios";
-import React, { Fragment, useState, useEffect } from "react";
+import React, { Fragment, useState, useEffect, useRef } from "react";
 import { Row, Col } from "react-bootstrap";
 import {
   InputLabelRequired,
@@ -16,21 +16,21 @@ const LojaFisica = (props) => {
   const [cidade, setCidade] = useState("");
   const [uf, setUf] = useState("");
   const [site, setSite] = useState("");
-  const [payload, setPayload] = useState({});
+  const payloadRef = useRef({});
   const [erro, setErro] = useState(false);
   const [nome_fantasia, setNomeFantasia] = useState("");
 
   useEffect(() => {
-    setTelefone(props.telefone);
-    setEndereco(props.endereco);
-    setCep(props.cep);
-    setBairro(props.bairro);
-    setCidade(props.cidade);
-    setUf(props.uf);
-    setNumero(props.numero);
-    setComplemento(props.complemento);
-    setNomeFantasia(props.nome_fantasia);
-    setSite(props.site);
+    if (props.telefone != null) setTelefone(props.telefone);
+    if (props.endereco != null) setEndereco(props.endereco);
+    if (props.cep != null) setCep(props.cep);
+    if (props.bairro != null) setBairro(props.bairro);
+    if (props.cidade != null) setCidade(props.cidade);
+    if (props.uf != null) setUf(props.uf);
+    if (props.numero != null) setNumero(props.numero);
+    if (props.complemento != null) setComplemento(props.complemento);
+    if (props.nome_fantasia != null) setNomeFantasia(props.nome_fantasia);
+    if (props.site != null) setSite(props.site);
   }, [props]);
 
   const buscaCep = async (value) => {
@@ -44,9 +44,9 @@ const LojaFisica = (props) => {
           if (data.cidade !== "São Paulo" || data.uf !== "SP") {
             setErro(true);
           } else {
-            const payload = populaPayload(data);
-            setPayload({ ...payload });
-            props.onUpdate(payload, props.chave);
+            const novo = populaPayload(data);
+            payloadRef.current = novo;
+            props.onUpdate(novo, props.chave);
           }
         }
       }
@@ -81,6 +81,10 @@ const LojaFisica = (props) => {
       bairro: data.bairro,
       cep: data.cep,
       nome_fantasia: nome_fantasia,
+      numero: numero,
+      complemento: complemento,
+      telefone: telefone,
+      site: site,
     };
   };
 
@@ -99,8 +103,8 @@ const LojaFisica = (props) => {
             onChange={(e) => {
               const valor = e.target.value;
               setNomeFantasia(valor);
-              setPayload({ ...payload, nome_fantasia: valor });
-              props.onUpdate({ ...payload, nome_fantasia: valor }, props.chave);
+              payloadRef.current = { ...payloadRef.current, nome_fantasia: valor };
+              props.onUpdate({ ...payloadRef.current }, props.chave);
             }}
           />
         </Col>
@@ -122,8 +126,8 @@ const LojaFisica = (props) => {
             onChange={(e) => {
               const valor = e.target.value;
               setCep(valor);
-              setPayload({ ...payload, cep: valor });
-              props.onUpdate(payload, props.chave);
+              payloadRef.current = { ...payloadRef.current, cep: valor };
+              props.onUpdate({ ...payloadRef.current }, props.chave);
             }}
             erro={erro}
             mensagem="A loja precisa estar em São Paulo-SP"
@@ -141,8 +145,8 @@ const LojaFisica = (props) => {
             onChange={(e) => {
               const valor = e.target.value;
               setBairro(valor);
-              setPayload({ ...payload, bairro: valor });
-              props.onUpdate(payload, props.chave);
+              payloadRef.current = { ...payloadRef.current, bairro: valor };
+              props.onUpdate({ ...payloadRef.current }, props.chave);
             }}
           />
         </Col>
@@ -160,8 +164,8 @@ const LojaFisica = (props) => {
             onChange={(e) => {
               const valor = e.target.value;
               setEndereco(valor);
-              setPayload({ ...payload, endereco: valor });
-              props.onUpdate({ ...payload, endereco: valor }, props.chave);
+              payloadRef.current = { ...payloadRef.current, endereco: valor };
+              props.onUpdate({ ...payloadRef.current }, props.chave);
             }}
           />
         </div>
@@ -175,8 +179,8 @@ const LojaFisica = (props) => {
             onChange={(e) => {
               const valor = e.target.value;
               setNumero(valor);
-              setPayload({ ...payload, numero: valor });
-              props.onUpdate(payload, props.chave);
+              payloadRef.current = { ...payloadRef.current, numero: valor };
+              props.onUpdate({ ...payloadRef.current }, props.chave);
             }}
           />
         </div>
@@ -189,8 +193,8 @@ const LojaFisica = (props) => {
             onChange={(e) => {
               const valor = e.target.value;
               setComplemento(valor);
-              setPayload({ ...payload, complemento: valor });
-              props.onUpdate(payload, props.chave);
+              payloadRef.current = { ...payloadRef.current, complemento: valor };
+              props.onUpdate({ ...payloadRef.current }, props.chave);
             }}
           />
         </div>
@@ -209,8 +213,8 @@ const LojaFisica = (props) => {
             onChange={(e) => {
               const valor = "São Paulo";
               setCidade(valor);
-              setPayload({ ...payload, cidade: valor });
-              props.onUpdate({ ...payload, cidade: valor }, props.chave);
+              payloadRef.current = { ...payloadRef.current, cidade: valor };
+              props.onUpdate({ ...payloadRef.current }, props.chave);
             }}
           />
         </div>
@@ -227,8 +231,8 @@ const LojaFisica = (props) => {
             onChange={(e) => {
               const valor = "SP";
               setUf(valor);
-              setPayload({ ...payload, uf: valor });
-              props.onUpdate({ ...payload, uf: valor }, props.chave);
+              payloadRef.current = { ...payloadRef.current, uf: valor };
+              props.onUpdate({ ...payloadRef.current }, props.chave);
             }}
           />
         </div>
@@ -247,8 +251,8 @@ const LojaFisica = (props) => {
             onChange={(e) => {
               const valor = e.target.value.replace("_", "");
               setTelefone(valor);
-              setPayload({ ...payload, telefone: valor });
-              props.onUpdate({ ...payload, telefone: valor }, props.chave);
+              payloadRef.current = { ...payloadRef.current, telefone: valor };
+              props.onUpdate({ ...payloadRef.current }, props.chave);
             }}
           />
         </div>
@@ -258,12 +262,12 @@ const LojaFisica = (props) => {
         value={site}
         disabled={props.empresa}
         id={`site_${props.chave}`}
-        onChange={(e) => {
-          const valor = e.target.value;
-          setSite(valor);
-          setPayload({ ...payload, site: valor });
-          props.onUpdate({ ...payload, site: valor }, props.chave);
-        }}
+            onChange={(e) => {
+              const valor = e.target.value;
+              setSite(valor);
+              payloadRef.current = { ...payloadRef.current, site: valor };
+              props.onUpdate({ ...payloadRef.current }, props.chave);
+            }}
       />
     </Fragment>
   );

--- a/src/screens/CadastroEmpresa/LojaFisica.jsx
+++ b/src/screens/CadastroEmpresa/LojaFisica.jsx
@@ -6,14 +6,6 @@ import {
   InputLabel,
 } from "components/Input/InputLabelRequired";
 import InputLabelRequiredMask from "components/Input/InputLabelRequiredMask";
-import { FileUpload } from "components/Input/FileUpload";
-import {
-  DOCUMENTO_ACCEPT,
-  DOCUMENTO_ACCEPT_CUSTOM,
-  DOCUMENTO_HELPER_TEXT,
-} from "helpers/fileUpload";
-
-
 const LojaFisica = (props) => {
   const [endereco, setEndereco] = useState("");
   const [numero, setNumero] = useState("");
@@ -27,7 +19,6 @@ const LojaFisica = (props) => {
   const [payload, setPayload] = useState({});
   const [erro, setErro] = useState(false);
   const [nome_fantasia, setNomeFantasia] = useState("");
-  const [comprovante_endereco, setComprovanteEndereco] = useState("");
 
   useEffect(() => {
     setTelefone(props.telefone);
@@ -40,9 +31,6 @@ const LojaFisica = (props) => {
     setComplemento(props.complemento);
     setNomeFantasia(props.nome_fantasia);
     setSite(props.site);
-    if (props.comprovante_endereco) {
-      setComprovanteEndereco(props.comprovante_endereco);
-    }
   }, [props]);
 
   const buscaCep = async (value) => {
@@ -277,54 +265,6 @@ const LojaFisica = (props) => {
           props.onUpdate({ ...payload, site: valor }, props.chave);
         }}
       />
-      <Row className="mt-2">
-        <Col>
-          {comprovante_endereco && typeof comprovante_endereco === "string" && (
-            <div className="pb-2">
-              <span className="font-weight-bold">
-                Comprovante de endereço atual: {" "}
-              </span>
-              <a target="blank" href={comprovante_endereco} rel="noopener noreferrer">
-                Visualizar arquivo
-              </a>
-            </div>
-          )}
-          <FileUpload
-            input={{
-              onChange: (data) => {
-                if (data && data.length > 0) {
-                  setComprovanteEndereco(data[0].arquivo);
-                  setPayload({ ...payload, comprovante_endereco: data[0].arquivo });
-                  props.onUpdate(
-                    { ...payload, comprovante_endereco: data[0].arquivo },
-                    props.chave
-                  );
-                } else {
-                  setComprovanteEndereco("");
-                  setPayload({ ...payload, comprovante_endereco: undefined });
-                  props.onUpdate(
-                    { ...payload, comprovante_endereco: undefined },
-                    props.chave
-                  );
-                }
-              },
-              value: [],
-            }}
-            label="Comprovante de endereço do ponto de venda"
-            accept={DOCUMENTO_ACCEPT}
-            acceptCustom={DOCUMENTO_ACCEPT_CUSTOM}
-            multiple={false}
-            disabled={props.empresa}
-            meta={{ touched: false, error: null }}
-            esconderAsterisco
-          />
-          <div className="campos-permitidos">
-            {DOCUMENTO_HELPER_TEXT}
-            <br />
-            Tamanho máximo: 5 MB
-          </div>
-        </Col>
-      </Row>
     </Fragment>
   );
 };

--- a/src/screens/CadastroEmpresa/LojaFisica.test.js
+++ b/src/screens/CadastroEmpresa/LojaFisica.test.js
@@ -4,7 +4,7 @@ import { mount } from "enzyme";
 import LojaFisica from "./LojaFisica";
 
 describe("CadastroEmpresa/LojaFisica", () => {
-  it("nao renderiza o campo de comprovante de endereco", () => {
+  it("renderiza o campo de comprovante de endereco", () => {
     const wrapper = mount(
       <LojaFisica
         bairro="Centro"
@@ -22,8 +22,31 @@ describe("CadastroEmpresa/LojaFisica", () => {
       />
     );
 
-    expect(wrapper.text()).not.toContain(
+    expect(wrapper.text()).toContain(
       "Comprovante de endereço do ponto de venda"
     );
+  });
+
+  it("exibe link do comprovante quando props.comprovante_endereco eh URL", () => {
+    const wrapper = mount(
+      <LojaFisica
+        bairro="Centro"
+        cep="01000-000"
+        chave={0}
+        cidade="São Paulo"
+        complemento=""
+        endereco="Rua A"
+        nome_fantasia="Loja Teste"
+        numero="10"
+        onUpdate={jest.fn()}
+        site=""
+        telefone="11999999999"
+        uf="SP"
+        comprovante_endereco="https://example.com/comprovante.pdf"
+      />
+    );
+
+    expect(wrapper.text()).toContain("Visualizar arquivo");
+    expect(wrapper.find("a[href='https://example.com/comprovante.pdf']")).toHaveLength(1);
   });
 });

--- a/src/screens/CadastroEmpresa/LojaFisica.test.js
+++ b/src/screens/CadastroEmpresa/LojaFisica.test.js
@@ -4,7 +4,7 @@ import { mount } from "enzyme";
 import LojaFisica from "./LojaFisica";
 
 describe("CadastroEmpresa/LojaFisica", () => {
-  it("renderiza o campo de comprovante de endereco", () => {
+  it("renderiza campos basicos", () => {
     const wrapper = mount(
       <LojaFisica
         bairro="Centro"
@@ -22,31 +22,8 @@ describe("CadastroEmpresa/LojaFisica", () => {
       />
     );
 
-    expect(wrapper.text()).toContain(
-      "Comprovante de endereço do ponto de venda"
-    );
-  });
-
-  it("exibe link do comprovante quando props.comprovante_endereco eh URL", () => {
-    const wrapper = mount(
-      <LojaFisica
-        bairro="Centro"
-        cep="01000-000"
-        chave={0}
-        cidade="São Paulo"
-        complemento=""
-        endereco="Rua A"
-        nome_fantasia="Loja Teste"
-        numero="10"
-        onUpdate={jest.fn()}
-        site=""
-        telefone="11999999999"
-        uf="SP"
-        comprovante_endereco="https://example.com/comprovante.pdf"
-      />
-    );
-
-    expect(wrapper.text()).toContain("Visualizar arquivo");
-    expect(wrapper.find("a[href='https://example.com/comprovante.pdf']")).toHaveLength(1);
+    expect(wrapper.text()).toContain("Nome Fantasia");
+    expect(wrapper.text()).toContain("CEP");
+    expect(wrapper.text()).toContain("Endereço");
   });
 });

--- a/src/screens/CadastroEmpresa/index.jsx
+++ b/src/screens/CadastroEmpresa/index.jsx
@@ -16,6 +16,7 @@ import "./style.scss";
 import LojaFisica from "./LojaFisica";
 import { validaOfertaUniforme, validaFormulario, getError } from "./helper";
 import { toastSuccess, toastError } from "components/Toast/dialogs";
+import { atualizaLojas } from "services/cadastro.service";
 import {
   cadastrarEmpresa,
   getTiposDocumentos,
@@ -25,7 +26,7 @@ import {
   getEmpresa,
   setAnexo,
   deleteAnexo,
-  setFachadaLoja,
+  setArquivoLoja,
   concluirCadastro,
   getLimites,
   verificaEmail,
@@ -48,6 +49,7 @@ import {
   BOTAO_ENVIAR_DOCUMENTOS_PARA_ANALISE,
   getBloqueioEnvioDocumentosParaAnalise,
 } from "helpers/documentosParaAnalise";
+import { montarPayloadAtualizaLojas } from "helpers/lojasPayload";
 export let CadastroEmpresa = (props) => {
   const initialValue = {
     nome_fantasia: undefined,
@@ -289,19 +291,18 @@ export let CadastroEmpresa = (props) => {
     const novoFornecimento = filtrarFornecimento(fornecimento);
 
     if (validaUniformes(novoFornecimento)) {
-      payload["lojas"] = loja.map((lojaPayload) => {
-        const lojaSemComprovante = { ...lojaPayload };
-
-        delete lojaSemComprovante.comprovante_endereco;
-
-        return lojaSemComprovante;
-      });
+      payload["lojas"] = loja;
       payload["meios_de_recebimento"] = bandeiras;
       payload["ofertas_de_uniformes"] = novoFornecimento;
       payload["arquivos_anexos"] = arquivosAnexos;
       payload["telefone"] = payload["telefone"].replace("_", "");
       delete payload["foto_fachada"];
       delete payload["arqs_anexos"];
+      Object.keys(payload).forEach((key) => {
+        if (key.startsWith("fachada_loja_") || key.startsWith("comprovante_loja_")) {
+          delete payload[key];
+        }
+      });
       const erro = validaFormulario(payload);
       if (erro) {
         toastError(erro);
@@ -396,16 +397,28 @@ export let CadastroEmpresa = (props) => {
     const arquivoAnexo = {
       foto_fachada: e[0].arquivo,
     };
-    let empresa_ = empresa;
-    empresa_.lojas[key].uploadEmAndamento = true;
+    let empresa_ = {
+      ...empresa,
+      lojas: empresa.lojas.map((lojaAtual, index) =>
+        index === key
+          ? { ...lojaAtual, uploadEmAndamento: true }
+          : lojaAtual
+      ),
+    };
     setEmpresa(empresa_);
     setAlgumUploadEmAndamento(true);
     forceUpdate();
-    setFachadaLoja(arquivoAnexo, uuidLoja).then((response) => {
+    setArquivoLoja(arquivoAnexo, uuidLoja).then((response) => {
       if (response.status === HTTP_STATUS.OK) {
         toastSuccess(ARQUIVO_SALVO_COM_SUCESSO);
-        let empresa_ = empresa;
-        empresa_.lojas[key].uploadEmAndamento = false;
+        let empresa_ = {
+          ...empresa,
+          lojas: empresa.lojas.map((lojaAtual, index) =>
+            index === key
+              ? { ...lojaAtual, uploadEmAndamento: false }
+              : lojaAtual
+          ),
+        };
         setEmpresa(empresa_);
         setAlgumUploadEmAndamento(false);
         getEmpresa(uuid).then((empresa) => {
@@ -413,8 +426,53 @@ export let CadastroEmpresa = (props) => {
         });
       } else {
         toastError("Erro ao dar upload no arquivo");
-        let empresa_ = empresa;
-        empresa_.lojas[key].uploadEmAndamento = false;
+        let empresa_ = {
+          ...empresa,
+          lojas: empresa.lojas.map((lojaAtual, index) =>
+            index === key
+              ? { ...lojaAtual, uploadEmAndamento: false }
+              : lojaAtual
+          ),
+        };
+        setEmpresa(empresa_);
+        setAlgumUploadEmAndamento(false);
+      }
+    });
+  };
+
+  const uploadComprovanteLoja = async (e, uuidLoja, key) => {
+    const payload = montarPayloadAtualizaLojas(
+      empresa,
+      uuidLoja,
+      "comprovante_endereco",
+      e[0].arquivo
+    );
+    let empresa_ = {
+      ...empresa,
+      lojas: empresa.lojas.map((lojaAtual, index) =>
+        index === key
+          ? { ...lojaAtual, uploadEmAndamento: true }
+          : lojaAtual
+      ),
+    };
+    setEmpresa(empresa_);
+    setAlgumUploadEmAndamento(true);
+    forceUpdate();
+    atualizaLojas(empresa.uuid, payload).then((response) => {
+      if (response.status === HTTP_STATUS.OK) {
+        toastSuccess(ARQUIVO_SALVO_COM_SUCESSO);
+        setEmpresaEFaltaArquivos(response.data);
+        setAlgumUploadEmAndamento(false);
+      } else {
+        toastError("Erro ao dar upload no arquivo");
+        let empresa_ = {
+          ...empresa,
+          lojas: empresa.lojas.map((lojaAtual, index) =>
+            index === key
+              ? { ...lojaAtual, uploadEmAndamento: false }
+              : lojaAtual
+          ),
+        };
         setEmpresa(empresa_);
         setAlgumUploadEmAndamento(false);
       }
@@ -426,12 +484,31 @@ export let CadastroEmpresa = (props) => {
       const arquivoAnexo = {
         foto_fachada: null,
       };
-      setFachadaLoja(arquivoAnexo, uuidLoja).then((response) => {
+      setArquivoLoja(arquivoAnexo, uuidLoja).then((response) => {
         if (response.status === HTTP_STATUS.OK) {
           toastSuccess("Arquivo excluído com sucesso!");
           getEmpresa(uuid).then((empresa) => {
             setEmpresaEFaltaArquivos(empresa.data);
           });
+        } else {
+          toastError("Erro ao dar excluir no arquivo");
+        }
+      });
+    }
+  };
+
+  const deleteComprovanteLoja = async (uuidLoja) => {
+    if (window.confirm("Deseja remover este anexo?")) {
+      const payload = montarPayloadAtualizaLojas(
+        empresa,
+        uuidLoja,
+        "comprovante_endereco",
+        null
+      );
+      atualizaLojas(empresa.uuid, payload).then((response) => {
+        if (response.status === HTTP_STATUS.OK) {
+          toastSuccess("Arquivo excluído com sucesso!");
+          setEmpresaEFaltaArquivos(response.data);
         } else {
           toastError("Erro ao dar excluir no arquivo");
         }
@@ -690,6 +767,7 @@ export let CadastroEmpresa = (props) => {
                         empresa.lojas.map((loja, key) => {
                           return !loja.foto_fachada ? (
                             <div
+                              key={`fachada_${loja.uuid || key}`}
                               className={`${
                                 algumUploadEmAndamento &&
                                 !loja.uploadEmAndamento
@@ -699,7 +777,7 @@ export let CadastroEmpresa = (props) => {
                             >
                               <Field
                                 component={FileUpload}
-                                name={`arqs_${key}`}
+                                name={`fachada_loja_${key}`}
                                 disabled={algumUploadEmAndamento}
                                 id={`${key}`}
                                 key={key}
@@ -730,7 +808,7 @@ export let CadastroEmpresa = (props) => {
                               )}
                             </div>
                           ) : (
-                            <div>
+                            <div key={`fachada_${loja.uuid || key}`}>
                               <ArquivoExistente
                                 label={`${loja.nome_fantasia} - ${loja.endereco}`}
                                 arquivo={loja.foto_fachada}
@@ -745,6 +823,80 @@ export let CadastroEmpresa = (props) => {
                   </div>
                   <div className="card w-100 mt-2">
                     <div className="card-body">
+                      <div className="card-title">
+                        Comprovantes de Endereço dos Pontos de Venda
+                      </div>
+                      {empresa &&
+                        empresa.lojas.map((loja, key) => {
+                          return loja.comprovante_endereco ? (
+                            <div key={`comprovante_${loja.uuid || key}`}>
+                              <ArquivoExistente
+                                label={`${loja.nome_fantasia} - ${loja.endereco}`}
+                                arquivo={loja.comprovante_endereco}
+                                lojaUuid={loja.uuid}
+                                proponenteStatus={empresa && empresa.status}
+                                removeAnexo={deleteComprovanteLoja}
+                              />
+                            </div>
+                          ) : empresa && empresa.status === "INSCRITO" ? (
+                            <div
+                              key={`comprovante_${loja.uuid || key}`}
+                              className="no-file-end-signup pt-3"
+                            >
+                              <div className="label">
+                                {`${loja.nome_fantasia} - ${loja.endereco}`}
+                              </div>
+                              <div>
+                                Seu cadastro foi finalizado e você não pode mais
+                                enviar este anexo.
+                              </div>
+                            </div>
+                          ) : (
+                            <div
+                              key={`comprovante_${loja.uuid || key}`}
+                              className={`${
+                                algumUploadEmAndamento &&
+                                !loja.uploadEmAndamento
+                                  ? "set-opacity"
+                                  : undefined
+                              } `}
+                            >
+                              <Field
+                                component={FileUpload}
+                                name={`comprovante_loja_${key}`}
+                                disabled={algumUploadEmAndamento}
+                                id={`comprovante_${key}`}
+                                key={`comprovante_${key}`}
+                                accept={DOCUMENTO_ACCEPT}
+                                acceptCustom={DOCUMENTO_ACCEPT_CUSTOM}
+                                className="form-control-file"
+                                label={`${loja.nome_fantasia} - ${loja.endereco}`}
+                                multiple={false}
+                                onChange={(e) => {
+                                  if (e.length > 0) {
+                                    uploadComprovanteLoja(e, loja.uuid, key);
+                                  }
+                                }}
+                              />
+                              <div className="campos-permitidos">
+                                {DOCUMENTO_HELPER_TEXT}
+                                <br />
+                                {TAMANHO_MAXIMO_UPLOAD}
+                              </div>
+                              {loja.uploadEmAndamento && (
+                                <span className="font-weight-bold">
+                                  {`Upload de documento em andamento. `}
+                                  <span className="red-word">Aguarde</span>
+                                  <span className="blink">...</span>
+                                </span>
+                              )}
+                            </div>
+                          );
+                        })}
+                    </div>
+                  </div>
+                  <div className="card w-100 mt-2">
+                    <div className="card-body">
                       <div className="card-title">Documentos Anexos</div>
                       {tiposDocumentos ? (
                         tiposDocumentos.map((tipo, key) => {
@@ -752,7 +904,7 @@ export let CadastroEmpresa = (props) => {
                             empresa.arquivos_anexos.find(
                               (arquivo) => arquivo.tipo_documento.id === tipo.id
                             ) ? (
-                            <div>
+                            <div key={`documento_${tipo.id}`}>
                               <ArquivoExistente
                                 label={labelTemplate(tipo)}
                                 arquivo={empresa.arquivos_anexos.find(
@@ -764,7 +916,7 @@ export let CadastroEmpresa = (props) => {
                               />
                             </div>
                           ) : empresa && empresa.status === "INSCRITO" ? (
-                            <div className="no-file-end-signup pt-3">
+                            <div key={`documento_${tipo.id}`} className="no-file-end-signup pt-3">
                               <div className="label">{labelTemplate(tipo)}</div>
                               <div>
                                 Seu cadastro foi finalizado e você não pode mais
@@ -773,6 +925,7 @@ export let CadastroEmpresa = (props) => {
                             </div>
                           ) : (
                             <div
+                              key={`documento_${tipo.id}`}
                               className={`${
                                 algumUploadEmAndamento &&
                                 !tipo.uploadEmAndamento

--- a/src/screens/CadastroEmpresa/index.jsx
+++ b/src/screens/CadastroEmpresa/index.jsx
@@ -671,7 +671,6 @@ export let CadastroEmpresa = (props) => {
                             endereco={empresa && value.endereco}
                             telefone={empresa && value.telefone}
                             site={empresa && value.site}
-                            comprovante_endereco={empresa && value.comprovante_endereco}
                             onUpdate={onUpdateLoja}
                           />
                           {!empresa && (

--- a/src/services/uniformes.service.js
+++ b/src/services/uniformes.service.js
@@ -116,7 +116,7 @@ export const deleteAnexo = (uuid) => {
     });
 };
 
-export const setFachadaLoja = (payload, uuid) => {
+export const setArquivoLoja = (payload, uuid) => {
   return axios
     .patch(`${endPont.API_URL}/lojas/${uuid}/`, payload, authHeader)
     .then((response) => {
@@ -127,9 +127,15 @@ export const setFachadaLoja = (payload, uuid) => {
     });
 };
 
+export const setFachadaLoja = (payload, uuid) => {
+  return setArquivoLoja(payload, uuid);
+};
+
 export const verificaCnpj = async (cnpj) => {
   const response = await axios.get(
-    `${endPont.API_URL}/proponentes/verifica-cnpj/?cnpj=${cnpj}`,
+    `${endPont.API_URL}/proponentes/verifica-cnpj/?cnpj=${encodeURIComponent(
+      String(cnpj || "").toUpperCase()
+    )}`,
     authHeader
   );
   return response.data;


### PR DESCRIPTION
## 🌿 Contexto

Frontend:
- Suporte ao upload de `comprovante_endereco` por loja nos fluxos de cadastro e anexos (logado e não logado), com validação de PDF, exibição do arquivo salvo e substituição.
- Atualização da máscara, validação e campo de CNPJ para aceitar formato alfanumérico, com normalização de entrada e manutenção de compatibilidade com CNPJ numérico legado.

## 🎯 Resumo

- **Loja:** o campo `comprovante_endereco`, que já existia no model `Loja`, passou a ficar visível no Django Admin, ganhou validação explícita de PDF no form/admin e cobertura de testes para visibilidade, validação e persistência. No frontend, foi adicionado input de upload por loja nos fluxos de cadastro e atualização, com exibição do comprovante já salvo e possibilidade de substituição.
- **CNPJ:** o backend e o frontend passaram a aceitar CNPJ alfanumérico, normalizando entrada, validando dígitos verificadores, tratando unicidade com máscara/case diferentes, refletindo isso no endpoint `verifica-cnpj`, na criação de usuários, no payload da TRIADE e em todos os campos de formulário do frontend.

## ✅ Entregas

### 🏬 Comprovante de Endereço por Loja

#### Frontend
- `src/screens/CadastroEmpresa/LojaFisica.jsx` — adicionado input de upload de PDF para `comprovante_endereco`, com exibição do link do arquivo já salvo e possibilidade de substituir.
- `src/screens/CadastroEmpresa/index.jsx` — adicionado card "Comprovantes de Endereço dos Pontos de Venda" na aba de Anexos (não logado), com upload, visualização e exclusão. Ajuste no submit do cadastro para preservar `comprovante_endereco` no payload das lojas.
- `src/screens/AreaLogada/AnexosLogado/Arquivos/index.jsx` — adicionado card "Comprovantes de Endereço dos Pontos de Venda" na área logada de anexos, com upload, visualização e exclusão. 
- `src/helpers/lojasPayload.js` — novo helper `montarPayloadAtualizaLojas` para montar o payload completo de atualização de lojas, preservando arquivos existentes de todas as lojas.
- `src/screens/AreaLogada/DadosEmpresaLogado/helpers.js` — `formataPayloadLojasPrecos` serializa corretamente `comprovante_endereco` quando o valor é um array de arquivo (upload novo), ou omite quando é apenas a URL já salva.
- `src/helpers/fileUpload.js` — validação de PDF já existente (`DOCUMENTO_ACCEPT`, `DOCUMENTO_ACCEPT_CUSTOM`) reaproveitada para o campo de comprovante.
- `src/screens/AreaLogada/DadosEmpresaLogado/Cadastro/components/DadosLoja/index.jsx` — **removido** o campo de upload de comprovante da tela de edição de dados da empresa (`/adm-fornecedor/dados-empresa`), mantendo o campo apenas na área de anexos.

### 🧾 Suporte a CNPJ Alfanumérico

#### Frontend
- `src/helpers/utils.js` — `validarCNPJ` atualizado para aceitar letras nas 12 primeiras posições e calcular DV com base no código ASCII. `compactarCNPJ` e `formatarCNPJ` adicionados para normalização e formatação.
- `src/helpers/textMask.js` — `fieldCNPJ` e `fieldCPF_CNPJ` atualizados para formatar com letras maiúsculas, mantendo compatibilidade com CNPJ numérico.
- `src/helpers/fieldValidators.js` — `validaCNPJ` agora usa `validarCNPJ` do `utils.js` (removeu dependência do pacote `cnpj`).
- `src/screens/AreaLogada/DadosEmpresaLogado/Cadastro/components/DadosEmpresa/index.jsx` — campo CNPJ agora usa `customChange={fieldCNPJ}` e `maxLength={18}` para aceitar e formatar o novo formato.
- `src/services/uniformes.service.js` — `verificaCnpj` envia o CNPJ em uppercase e com `encodeURIComponent` para suportar caracteres alfanuméricos na query string.
- `src/screens/CadastroEmpresa/DadosEmpresa.jsx` — campo CNPJ já usa `fieldCNPJ` via `customChange`, herdando o suporte alfanumérico.

## 🧪 Testes Criados e Alterados

### Frontend
- `src/helpers/lojasPayload.test.js`: cobre o helper `montarPayloadAtualizaLojas`, validando que o payload inclui `comprovante_endereco` apenas para a loja alterada e preserva os campos de arquivo das outras lojas.
- `src/screens/AreaLogada/DadosEmpresaLogado/helpers.test.js`: cobre `formataPayloadLojasPrecos`, validando serialização de `comprovante_endereco` quando é um novo upload (array) vs. quando é uma URL já salva (string).
- `src/screens/CadastroEmpresa/LojaFisica.test.js`: cobre renderização do campo de upload de comprovante e exibição do link quando `comprovante_endereco` é uma URL.
- `src/screens/AreaLogada/DadosEmpresaLogado/Cadastro/components/DadosLoja/index.test.jsx`: cobre que o campo de comprovante não é renderizado na tela de edição de dados da empresa (apenas em anexos).
- `src/helpers/utils.test.js`: cobre `validarCNPJ`, `compactarCNPJ` e `formatarCNPJ` com casos de CNPJ numérico legado e alfanumérico.
- `src/helpers/fieldValidators.test.js`: cobre `validaCNPJ` com CNPJ numérico válido/inválido e alfanumérico válido/inválido.
- `src/helpers/textMask.test.js`: cobre `fieldCNPJ` e `fieldCPF_CNPJ` com formatação de CNPJ numérico e alfanumérico.
- `src/helpers/fileUpload.test.js`: cobre rejeição de PDF para upload de fachada (imagens apenas).

## ▶️ Validação Executada

### Frontend

Suíte focada do escopo alterado:

Comando:

```bash
docker compose -f docker-compose-dev.yml exec frontend sh -c \
    "npm test -- --watchAll=false --testPathPattern='(LojaFisica|DadosLoja|fileUpload|utils|fieldValidators|textMask|lojasPayload|helpers.test)'"
```

Resultado: `9 passed, 42 tests passed`.
